### PR TITLE
Set Heap Memory to 4 GiB and Log Mem and #Procs at Startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,6 @@ WORKDIR /app
 USER 1001
 
 ENV FLARE_CACHE_DISK_PATH="/app/cache"
+ENV JAVA_TOOL_OPTIONS="-Xmx4g"
 
 CMD ["java", "-jar", "flare.jar"]

--- a/README.md
+++ b/README.md
@@ -50,6 +50,22 @@ docker run -p 8080:8080 ghcr.io/medizininformatik-initiative/flare:main
 | FLARE_MAPPING_MAPPINGSFILE    | ontology/codex-term-code-mapping.json |                                                                                                  |
 | FLARE_MAPPING_CONCEPTTREEFILE | ontology/codex-code-tree.json         |                                                                                                  |
 | SERVER_PORT                   | 8080                                  | The port at which Flare provides its REST API.                                                   |
+| JAVA_TOOL_OPTIONS             | -Xmx4g                                | JVM options \(Docker only\)                                                                      |
+
+## Default Configuration
+
+The default configuration assumes the following:
+
+* there is about 8 GiB od memory available for Flare 
+  * 4 GiB Java heap including 1 GiB in-memory Cache
+  * about 1 GiB Java off-heap memory especially for the disk-based cache
+  * about 3 GiB for page cache and the rest of the operating system
+* there is plenty of disk space
+  * the disk space used by the disk-based cache is not constrained right now
+  * cache entries life for at least 7 days per default
+  * disk space is only reclaimed on a best-effort base
+* the FHIR endpoint is capable of handling 32 requests in parallel
+* the FHIR endpoint is capable of returning pages of size 1000 or constrain the page size itself
 
 ## License
 

--- a/src/main/java/de/medizininformatikinitiative/flare/FlareApplication.java
+++ b/src/main/java/de/medizininformatikinitiative/flare/FlareApplication.java
@@ -40,6 +40,8 @@ public class FlareApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(FlareApplication.class, args);
+        logger.info("Maximum available memory: {} MiB", Runtime.getRuntime().maxMemory() / 1024 / 1024);
+        logger.info("Number of available processors: {}", Runtime.getRuntime().availableProcessors());
     }
 
     @Bean


### PR DESCRIPTION
Because we have configured a in-memory cache of 1 GiB by default, we need to ensure that the Java heap has at least a maximum of 4 GiB.