### PR TITLE
Improve the Population Storage Size and Operation Performance

### DIFF
--- a/docs/load-tests.md
+++ b/docs/load-tests.md
@@ -2,44 +2,44 @@
 
 ## Union Top 10 Conditions
 
-This test uses a query about the [the union of the top 10 most frequent conditions](synthea/condition-query-union-top-10.json) and runs it with a rate of two times per second for a duration of 60 seconds.
+This test uses a query about the [the union of the top 10 most frequent conditions](synthea/condition-query-union-top-10.json) and runs it with a rate of ten times per second for a duration of 60 seconds.
 
 ```sh
 jq -scM '.[0].body = (.[1] | @base64) | .[0]' load-tests/execute.json synthea/condition-query-union-top-10.json |\
-vegeta attack -rate=2 -format=json -duration=60s | \
+vegeta attack -rate=10 -format=json -duration=60s | \
 vegeta report
 ```
 
 Result:
 
 ```text
-Requests      [total, rate, throughput]         120, 2.02, 1.95
-Duration      [total, attack, wait]             1m2s, 59.499s, 2.183s
-Latencies     [min, mean, 50, 90, 95, 99, max]  1.832s, 2.747s, 2.582s, 3.28s, 4.047s, 4.324s, 4.351s
-Bytes In      [total, mean]                     720, 6.00
-Bytes Out     [total, mean]                     129840, 1082.00
+Requests      [total, rate, throughput]         600, 10.02, 10.00
+Duration      [total, attack, wait]             59.991s, 59.9s, 90.809ms
+Latencies     [min, mean, 50, 90, 95, 99, max]  64.906ms, 74.969ms, 72.419ms, 82.132ms, 93.32ms, 101.689ms, 189.035ms
+Bytes In      [total, mean]                     3600, 6.00
+Bytes Out     [total, mean]                     649200, 1082.00
 Success       [ratio]                           100.00%
-Status Codes  [code:count]                      200:120
+Status Codes  [code:count]                      200:600
 ```
 
 ## Intersection Top 10 Conditions
 
-This test uses a query about the [the intersection of the top 10 most frequent conditions](synthea/condition-query-intersection-top-10.json) and runs it with a rate of two times per second for a duration of 60 seconds.
+This test uses a query about the [the intersection of the top 10 most frequent conditions](synthea/condition-query-intersection-top-10.json) and runs it with a rate of ten times per second for a duration of 60 seconds.
 
 ```sh
 jq -scM '.[0].body = (.[1] | @base64) | .[0]' load-tests/execute.json synthea/condition-query-intersection-top-10.json |\
-vegeta attack -rate=2 -format=json -duration=60s | \
+vegeta attack -rate=10 -format=json -duration=60s | \
 vegeta report
 ```
 
 Result:
 
 ```text
-Requests      [total, rate, throughput]         120, 2.02, 1.80
-Duration      [total, attack, wait]             1m6s, 59.5s, 6.989s
-Latencies     [min, mean, 50, 90, 95, 99, max]  1.453s, 11.769s, 11.388s, 16.688s, 17.48s, 22.138s, 22.487s
-Bytes In      [total, mean]                     480, 4.00
-Bytes Out     [total, mean]                     132000, 1100.00
+Requests      [total, rate, throughput]         600, 10.02, 10.00
+Duration      [total, attack, wait]             59.999s, 59.9s, 99.469ms
+Latencies     [min, mean, 50, 90, 95, 99, max]  46.537ms, 87.491ms, 85.925ms, 96.824ms, 99.819ms, 186.572ms, 200.036ms
+Bytes In      [total, mean]                     2400, 4.00
+Bytes Out     [total, mean]                     660000, 1100.00
 Success       [ratio]                           100.00%
-Status Codes  [code:count]                      200:120
+Status Codes  [code:count]                      200:600
 ```

--- a/src/main/java/de/medizininformatikinitiative/flare/model/Population.java
+++ b/src/main/java/de/medizininformatikinitiative/flare/model/Population.java
@@ -13,15 +13,21 @@ import static java.util.Objects.requireNonNull;
  * A Population is an immutable set of patient ids.
  * <p>
  * Patient ids can have a maximum length of 64 chars.
+ * <p>
+ * Uses a sorted array of patient ids internally to store the patient ids memory efficient and facilitate fast
+ * operations like {@link #intersection(Population) intersection}, {@link #union(Population) union} and
+ * {@link #difference(Population) difference}.
+ * <p>
+ * Note: {@link #contains(Object) contains} is O(n)
  */
 public final class Population extends AbstractSet<String> {
 
-    private static final Population EMPTY = new Population(new HashSet<>(0), Instant.EPOCH);
+    private static final Population EMPTY = new Population(new String[0], Instant.EPOCH);
 
-    private final Set<String> patientIds;
+    private final String[] patientIds;
     private final Instant created;
 
-    private Population(Set<String> patientIds, Instant created) {
+    private Population(String[] patientIds, Instant created) {
         this.patientIds = patientIds;
         this.created = created;
     }
@@ -32,20 +38,40 @@ public final class Population extends AbstractSet<String> {
 
     public static Population of(String patientId1) {
         checkPatientId(patientId1);
-        return new Population(Set.of(patientId1.intern()), Instant.EPOCH);
+        return new Population(new String[]{patientId1.intern()}, Instant.EPOCH);
     }
 
+    /**
+     * Returns an immutable population containing two patient ids.
+     *
+     * @param patientId1 the first patient id
+     * @param patientId2 the second patient id
+     * @return a {@code Population} containing the specified patient ids
+     * @throws IllegalArgumentException if one of the patient ids is longer than 64 chars or if the patient ids are
+     *                                  duplicates
+     * @throws NullPointerException     if a patient id is {@code null}
+     */
     public static Population of(String patientId1, String patientId2) {
         checkPatientId(patientId1);
         checkPatientId(patientId2);
-        return new Population(Set.of(patientId1.intern(), patientId2.intern()), Instant.EPOCH);
+        var id1 = patientId1.intern();
+        var id2 = patientId2.intern();
+        if (id1.equals(id2)) {
+            throw new IllegalArgumentException("duplicate patient id: " + id1);
+        }
+        return new Population(id1.compareTo(id2) < 0 ? new String[]{id1, id2} : new String[]{id2, id1}, Instant.EPOCH);
     }
 
     public static Population copyOf(Collection<String> patientIds) {
-        for (String id : patientIds) {
+        var idSet = Set.copyOf(patientIds);
+        String[] internedIds = new String[idSet.size()];
+        int i = 0;
+        for (String id : idSet) {
             checkPatientId(id);
+            internedIds[i++] = id.intern();
         }
-        return new Population(Set.copyOf(patientIds.stream().map(String::intern).toList()), Instant.EPOCH);
+        Arrays.sort(internedIds);
+        return new Population(internedIds, Instant.EPOCH);
     }
 
     /**
@@ -71,52 +97,103 @@ public final class Population extends AbstractSet<String> {
 
     @Override
     public boolean isEmpty() {
-        return patientIds.isEmpty();
+        return patientIds.length == 0;
     }
 
     @Override
     public Iterator<String> iterator() {
-        return patientIds.iterator();
+        return new PatientIdIterator();
     }
 
     @Override
     public int size() {
-        return patientIds.size();
+        return patientIds.length;
     }
 
     /**
      * Returns the size of this population in memory.
      * <p>
-     * The calculation assumes that an {@link Set#of immutable set} is used to tore the patient ids internally. In
-     * addition it assumes that alle patient ids are {@link String#intern() interned}. Such sets use an array of double
-     * the size of the set to store entries. Each entry is a reference to a string. References have a size of 4 bytes.
+     * The calculation uses the fact that an array is used to store the patient ids internally. In addition it assumes
+     * that all patient ids are {@link String#intern() interned}. Each entry is a reference to a string. References
+     * have a size of 4 bytes.
      * <p>
-     * So the memory size is 24 bytes for the population class, 24 bytes for the instant, 24 bytes for the immutable set
-     * and 8 times the size of the immutable set for the object array holding the string references. The strings itself
-     * do not count, because they are interned.
+     * So the memory size is 24 bytes for the population class, 24 bytes for the instant, 16 bytes for the array and 4
+     * times the size of the array for the array holding the string references. The strings itself do not count, because
+     * they are interned.
      *
      * @return the size of this population in memory
      */
     public int memSize() {
-        return 72 + patientIds.size() * 8;
+        return 64 + patientIds.length * 4;
     }
 
     public Population intersection(Population other) {
-        var ret = new HashSet<>(patientIds);
-        ret.retainAll(other.patientIds);
-        return new Population(ret, created.isBefore(other.created) ? created : other.created);
+        int i = 0, j = 0, r = 0;
+        var res = new String[Math.min(patientIds.length, other.patientIds.length)];
+
+        while (i < patientIds.length && j < other.patientIds.length) {
+            int cmp = patientIds[i].compareTo(other.patientIds[j]);
+            if (cmp < 0) {
+                i++;
+            } else if (cmp > 0) {
+                j++;
+            } else {
+                res[r++] = patientIds[i++];
+                j++;
+            }
+        }
+
+        return new Population(Arrays.copyOf(res, r), created.isBefore(other.created) ? created : other.created);
     }
 
     public Population union(Population other) {
-        var ret = new HashSet<>(patientIds);
-        ret.addAll(other.patientIds);
-        return new Population(ret, created.isBefore(other.created) ? created : other.created);
+        int i = 0, j = 0, r = 0;
+        var res = new String[patientIds.length + other.patientIds.length];
+
+        while (i < patientIds.length && j < other.patientIds.length) {
+            int cmp = patientIds[i].compareTo(other.patientIds[j]);
+            if (cmp < 0) {
+                res[r++] = patientIds[i++];
+            } else if (cmp > 0) {
+                res[r++] = other.patientIds[j++];
+            } else {
+                res[r++] = patientIds[i++];
+                j++;
+            }
+        }
+
+        while (i < patientIds.length) {
+            res[r++] = patientIds[i++];
+        }
+
+        while (j < other.patientIds.length) {
+            res[r++] = other.patientIds[j++];
+        }
+
+        return new Population(Arrays.copyOf(res, r), created.isBefore(other.created) ? created : other.created);
     }
 
     public Population difference(Population other) {
-        var ret = new HashSet<>(patientIds);
-        ret.removeAll(other.patientIds);
-        return new Population(ret, created.isBefore(other.created) ? created : other.created);
+        int i = 0, j = 0, r = 0;
+        var res = new String[patientIds.length];
+
+        while (i < patientIds.length && j < other.patientIds.length) {
+            int cmp = patientIds[i].compareTo(other.patientIds[j]);
+            if (cmp < 0) {
+                res[r++] = patientIds[i++];
+            } else if (cmp > 0) {
+                j++;
+            } else {
+                i++;
+                j++;
+            }
+        }
+
+        while (i < patientIds.length) {
+            res[r++] = patientIds[i++];
+        }
+
+        return new Population(Arrays.copyOf(res, r), created.isBefore(other.created) ? created : other.created);
     }
 
     @Override
@@ -127,12 +204,12 @@ public final class Population extends AbstractSet<String> {
         if (!(o instanceof Population p))
             return false;
 
-        return created.equals(p.created) && patientIds.equals(p.patientIds);
+        return created.equals(p.created) && Arrays.equals(patientIds, p.patientIds);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(created, patientIds);
+        return Objects.hash(created, Arrays.hashCode(patientIds));
     }
 
     @Override
@@ -145,6 +222,7 @@ public final class Population extends AbstractSet<String> {
         byteBuffer.put((byte) 0); //version byte
 
         byteBuffer.putLong(created.getEpochSecond());
+        byteBuffer.putInt(patientIds.length);
 
         for (String id : patientIds) {
             byte[] bytes = id.getBytes(US_ASCII);
@@ -156,7 +234,7 @@ public final class Population extends AbstractSet<String> {
     }
 
     private int serializedSize() {
-        return patientIds.stream().mapToInt(id -> id.getBytes(US_ASCII).length + 1).sum() + 9;
+        return Arrays.stream(patientIds).mapToInt(id -> id.getBytes(US_ASCII).length + 1).sum() + 13;
     }
 
     public static Population fromByteBuffer(ByteBuffer byteBuffer) throws SerializerException {
@@ -171,18 +249,38 @@ public final class Population extends AbstractSet<String> {
 
         var created = Instant.ofEpochSecond(byteBuffer.getLong());
 
-        var patientIds = new ArrayList<String>();
-        while (byteBuffer.remaining() > 0) {
+        var patientIds = new String[byteBuffer.getInt()];
+        int i = 0;
+        while (i < patientIds.length) {
             byte[] idBytes = new byte[byteBuffer.get()];
             byteBuffer.get(idBytes);
-            patientIds.add(new String(idBytes, US_ASCII).intern());
+            patientIds[i++] = new String(idBytes, US_ASCII).intern();
         }
-        return new Population(Set.copyOf(patientIds), created);
+        return new Population(patientIds, created);
     }
 
     private static void checkPatientId(String patientId1) {
         if (patientId1.length() > 64) {
             throw new IllegalArgumentException("Patient id `%s` is longer as 64 chars.".formatted(patientId1));
+        }
+    }
+
+    private class PatientIdIterator implements Iterator<String> {
+
+        private int cursor;
+
+        @Override
+        public boolean hasNext() {
+            return cursor != patientIds.length;
+        }
+
+        @Override
+        public String next() {
+            try {
+                return patientIds[cursor++];
+            } catch (IndexOutOfBoundsException e) {
+                throw new NoSuchElementException();
+            }
         }
     }
 }


### PR DESCRIPTION
Storage size is cut down by half. One patient id now only costs 4 byte of memory instead of 8. The speed of intersection has improved 100x and union 25x. The memory needed to compute union has cut down about 4 times. The trick is to use sorted arrays as set representation instead of using HashSets.