### PR TITLE
Fix StackOverflow while Expanding Criteria

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/Monos.java
+++ b/src/main/java/de/medizininformatikinitiative/Monos.java
@@ -1,0 +1,19 @@
+package de.medizininformatikinitiative;
+
+import de.medizininformatikinitiative.flare.Either;
+import reactor.core.publisher.Mono;
+
+public interface Monos {
+
+    /**
+     * Creates a {@code Mono} from an {@code Either}.
+     *
+     * @param either the {@code Either}
+     * @param <T>    the type of the right value of the {@code Either} and the completed value of the {@code Mono}
+     * @return either a {@code Mono} representing an error if the {@code either} is left or a {@code Mono} representing
+     * a completed value if the {@code either} is right
+     */
+    static <T> Mono<T> ofEither(Either<Exception, T> either) {
+        return either.either(Mono::error, Mono::just);
+    }
+}

--- a/src/main/java/de/medizininformatikinitiative/flare/Either.java
+++ b/src/main/java/de/medizininformatikinitiative/flare/Either.java
@@ -1,0 +1,201 @@
+package de.medizininformatikinitiative.flare;
+
+import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A union type of either a {@link Either.Left left} or a {@link Either.Right right} value.
+ *
+ * <p>Usually Right denotes the happy path and Left denotes the exception case. Operations like {@link #map(Function)
+ * map} and {@link #flatMap(Function) flatMap} are right-based. So they operate on the right value and shortcut in the
+ * case the Either is {@link Either.Left left}.
+ *
+ * @param <L> the type of the left value
+ * @param <R> the type of the right value
+ */
+public sealed interface Either<L, R> permits Either.Left, Either.Right {
+
+    /**
+     * Wraps the given value into a {@link Either.Left Left Either}.
+     *
+     * @param val the value to wrap
+     * @param <L> the type of the left value
+     * @param <R> the type of the right value
+     * @return a Left Either
+     */
+    static <L, R> Either<L, R> left(L val) {
+        return new Left<>(val);
+    }
+
+    /**
+     * Wraps the given value into a {@link Either.Right Right Either}.
+     *
+     * @param val the value to wrap
+     * @param <L> the type of the left value
+     * @param <R> the type of the right value
+     * @return a Right Either
+     */
+    static <L, R> Either<L, R> right(R val) {
+        return new Right<>(val);
+    }
+
+    /**
+     * Lifts the function {@code f} into the {@code Either} type.
+     *
+     * <p>The lifted function will return it's argument if it is {@link Either.Left left} without calling {@code f},
+     * also called shortcutting. In case the argument is {@link Either.Right right}, the function will call {@code f}
+     * with the {@link Either.Right#val right value} and return the result wrapped into a {@link Either.Right
+     * Right Either}.
+     *
+     * <p>Applying the lifted function to an {@code Either} is the same as calling {@link #map(Function) map} with
+     * {@code f}.
+     *
+     * @param f   the function to lift
+     * @param <L> the left type of all Eithers
+     * @param <T> the argument type of {@code f}
+     * @param <R> the result type of {@code f}
+     * @return a function that takes an {@code Either<L, T>} instead of a {@code T} and returns an {@code Either<L, R>}
+     * instead of a {@code R}
+     */
+    static <L, T, R> Function<Either<L, T>, Either<L, R>> lift(Function<T, R> f) {
+        requireNonNull(f, "f");
+        return either -> either.map(f);
+    }
+
+    /**
+     * Lifts the function {@code f} into the {@code Either} type.
+     *
+     * <p>The lifted function will return one of it's arguments if it is {@link Either.Left left} without calling
+     * {@code f}, also called shortcutting. In case both arguments are {@link Either.Right right}, the function will
+     * call {@code f} and return the result wrapped into a {@link Either.Right Right Either}.
+     *
+     * <p>Lifting an existing function is useful in
+     * {@link java.util.stream.Stream#reduce(Object, BiFunction, BinaryOperator) reducing} streams of eithers.
+     *
+     * @param f   the function to lift
+     * @param <L> the left type of all Eithers
+     * @param <T> the type of the first argument of {@code f}
+     * @param <U> the type of the second argument of {@code f}
+     * @param <R> the result type of {@code f}
+     * @return a function that takes an {@code Either<L, T>} and an {@code Either<L, U>} instead of a {@code T} and an
+     * {@code U} and returns an {@code Either<L, R>} instead of a {@code R}
+     */
+    static <L, T, U, R> BiFunction<Either<L, T>, Either<L, U>, Either<L, R>> lift2(BiFunction<T, U, R> f) {
+        requireNonNull(f, "f");
+        return (eitherA, eitherB) -> eitherA.flatMap(a -> eitherB.map(b -> f.apply(a, b)));
+    }
+
+    /**
+     * Lifts the binary operator {@code op} into the {@code Either} type.
+     *
+     * <p>The lifted operator will return one of it's arguments if it is {@link Either.Left left} without calling
+     * {@code op}, also called shortcutting. In case both arguments are {@link Either.Right right}, the operator will
+     * call {@code op} and return the result wrapped into a {@link Either.Right Right Either}.
+     *
+     * <p>Lifting an existing operators is useful in {@link java.util.stream.Stream#reduce(BinaryOperator) reducing}
+     * streams of Eithers.
+     *
+     * @param op  the operator to lift
+     * @param <L> the left type of all Eithers
+     * @param <T> the type of {@code op}
+     * @return an operator that takes two {@code Either<L, T>}s of two {@code T}s and returns an {@code Either<L, T>}
+     * instead of a {@code T}
+     */
+    static <L, T> BinaryOperator<Either<L, T>> liftBinOp(BinaryOperator<T> op) {
+        requireNonNull(op, "op");
+        return (eitherA, eitherB) -> eitherA.flatMap(a -> eitherB.map(b -> op.apply(a, b)));
+    }
+
+    /**
+     * If this {@code Either} is {@link Either.Right right}, returns the result of applying the given mapping function
+     * to the {@link Either.Right#val right value} wrapped into a {@link Either.Right Right Either}, otherwise returns
+     * the left {@code Either} unchanged.
+     *
+     * @param mapper the mapping function to apply to a right value
+     * @param <U>    the type of the mapped right value
+     * @return a mapped right value wrapped in a {@code Right Either} or an unchanged left {@code Either}
+     * @throws NullPointerException if the mapping function is {@code null}
+     */
+    <U> Either<L, U> map(Function<? super R, ? extends U> mapper);
+
+    /**
+     * If this {@code Either} is {@link Either.Right right}, returns the result of applying the given mapping function
+     * to the {@link Either.Right#val right value}, otherwise returns the left {@code Either} unchanged.
+     *
+     * @param mapper the mapping function to apply to a right value
+     * @param <U>    the type of the mapped right value
+     * @return a mapped right value or an unchanged left {@code Either}
+     * @throws NullPointerException if the mapping function is {@code null}
+     */
+    <U> Either<L, U> flatMap(Function<? super R, ? extends Either<L, U>> mapper);
+
+    /**
+     * Maps both, the right and the left value to a value of a common type {@code T}.
+     *
+     * @param leftMapper  the mapping function that is applied to the left value
+     * @param rightMapper the mapping function that is applied to the right value
+     * @param <T>         the type of the return value
+     * @return the return value of either either applying the left value to the {@code leftMapper} or the right value to
+     * the {@code rightMapper}
+     * @throws NullPointerException if one of the mapping functions is {@code null}
+     */
+    <T> T either(Function<? super L, ? extends T> leftMapper, Function<? super R, ? extends T> rightMapper);
+
+    /**
+     * A container representing the left value.
+     *
+     * @param <L> the type of the left value
+     * @param <R> the type of the right value
+     */
+    record Left<L, R>(L val) implements Either<L, R> {
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <U> Either<L, U> map(Function<? super R, ? extends U> mapper) {
+            return (Either<L, U>) this;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <U> Either<L, U> flatMap(Function<? super R, ? extends Either<L, U>> mapper) {
+            return (Either<L, U>) this;
+        }
+
+        @Override
+        public <T> T either(Function<? super L, ? extends T> leftMapper, Function<? super R, ? extends T> rightMapper) {
+            requireNonNull(leftMapper, "left mapper");
+            return leftMapper.apply(val);
+        }
+    }
+
+    /**
+     * A container representing the left value.
+     *
+     * @param val the right value
+     * @param <L> the type of the left value
+     * @param <R> the type of the right value
+     */
+    record Right<L, R>(R val) implements Either<L, R> {
+
+        @Override
+        public <U> Either<L, U> map(Function<? super R, ? extends U> mapper) {
+            requireNonNull(mapper);
+            return new Right<>(mapper.apply(val));
+        }
+
+        @Override
+        public <U> Either<L, U> flatMap(Function<? super R, ? extends Either<L, U>> mapper) {
+            requireNonNull(mapper, "mapper");
+            return mapper.apply(val);
+        }
+
+        @Override
+        public <T> T either(Function<? super L, ? extends T> leftMapper, Function<? super R, ? extends T> rightMapper) {
+            requireNonNull(rightMapper, "right mapper");
+            return rightMapper.apply(val);
+        }
+    }
+}

--- a/src/main/java/de/medizininformatikinitiative/flare/Util.java
+++ b/src/main/java/de/medizininformatikinitiative/flare/Util.java
@@ -1,22 +1,12 @@
 package de.medizininformatikinitiative.flare;
 
-import reactor.core.publisher.Mono;
-
-import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Stream;
 
 public interface Util {
 
-    static <T> List<T> add(List<T> xs, T x) {
-        LinkedList<T> rs = new LinkedList<>(xs);
-        rs.add(x);
-        return List.copyOf(rs);
-    }
-
-    static <T> List<List<T>> add(List<List<T>> xs, List<T> x) {
-        LinkedList<List<T>> rs = new LinkedList<>(xs);
-        rs.add(x);
-        return List.copyOf(rs);
+    static <T, U extends T> List<T> add(List<T> xs, U x) {
+        return Stream.concat(xs.stream(), Stream.of(x)).toList();
     }
 
     /**
@@ -60,17 +50,7 @@ public interface Util {
         return newResult;
     }
 
-    static <T> List<T> concat(List<T> as, List<T> bs) {
-        LinkedList<T> rs = new LinkedList<>(as);
-        rs.addAll(bs);
-        return List.copyOf(rs);
-    }
-
-    static <T> Mono<List<List<T>>> add(Mono<List<List<T>>> monoR, Mono<List<T>> monoXs) {
-        return monoR.flatMap(r -> monoXs.map(xs -> Util.add(r, xs)));
-    }
-
-    static <T> Mono<List<T>> concat(Mono<List<T>> mA, Mono<List<T>> mB) {
-        return mA.flatMap(a -> mB.map(b -> Util.concat(a, b)));
+    static <T> List<T> concat(List<T> as, List<? extends T> bs) {
+        return Stream.concat(as.stream(), bs.stream()).toList();
     }
 }

--- a/src/main/java/de/medizininformatikinitiative/flare/model/mapping/Mapping.java
+++ b/src/main/java/de/medizininformatikinitiative/flare/model/mapping/Mapping.java
@@ -3,8 +3,8 @@ package de.medizininformatikinitiative.flare.model.mapping;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import de.medizininformatikinitiative.flare.Either;
 import de.medizininformatikinitiative.flare.model.sq.TermCode;
-import reactor.core.publisher.Mono;
 
 import java.util.*;
 import java.util.function.Function;
@@ -109,9 +109,9 @@ public final class Mapping {
         return fixedCriteria;
     }
 
-    public Mono<AttributeMapping> findAttributeMapping(TermCode code) {
+    public Either<Exception, AttributeMapping> findAttributeMapping(TermCode code) {
         AttributeMapping mapping = attributeMappings.get(code);
-        return mapping == null ? Mono.error(new AttributeMappingNotFoundException(key, code)) : Mono.just(mapping);
+        return mapping == null ? Either.left(new AttributeMappingNotFoundException(key, code)) : Either.right(mapping);
     }
 
     public String timeRestrictionParameter() {

--- a/src/main/java/de/medizininformatikinitiative/flare/model/mapping/MappingContext.java
+++ b/src/main/java/de/medizininformatikinitiative/flare/model/mapping/MappingContext.java
@@ -1,8 +1,8 @@
 package de.medizininformatikinitiative.flare.model.mapping;
 
+import de.medizininformatikinitiative.flare.Either;
 import de.medizininformatikinitiative.flare.model.sq.Concept;
 import de.medizininformatikinitiative.flare.model.sq.TermCode;
-import reactor.core.publisher.Mono;
 
 import java.time.Clock;
 import java.time.LocalDate;
@@ -59,20 +59,20 @@ public class MappingContext {
      * @param key the TermCode of the mapping
      * @return either the Mapping or {@code Optional#empty() nothing}
      */
-    public Mono<Mapping> findMapping(TermCode key) {
+    public Either<Exception, Mapping> findMapping(TermCode key) {
         var mapping = mappings.get(requireNonNull(key));
-        return mapping == null ? Mono.error(new MappingNotFoundException(key)) : Mono.just(mapping);
+        return mapping == null ? Either.left(new MappingNotFoundException(key)) : Either.right(mapping);
     }
 
     /**
-     * Expands {@code concept} into a {@link Mono mono} of {@link TermCode term codes}.
+     * Expands {@code concept} into a {@link Either either} of {@link TermCode term codes}.
      *
      * @param concept the concept to expand
      * @return the mono of term codes
      */
-    public Mono<List<TermCode>> expandConcept(Concept concept) {
+    public Either<Exception, List<TermCode>> expandConcept(Concept concept) {
         var termCodes = concept.termCodes().stream().flatMap(conceptTree::expand).toList();
-        return termCodes.isEmpty() ? Mono.error(new ConceptNotExpandableException(concept)) : Mono.just(termCodes);
+        return termCodes.isEmpty() ? Either.left(new ConceptNotExpandableException(concept)) : Either.right(termCodes);
     }
 
     /**

--- a/src/main/java/de/medizininformatikinitiative/flare/model/sq/AttributeFilter.java
+++ b/src/main/java/de/medizininformatikinitiative/flare/model/sq/AttributeFilter.java
@@ -2,9 +2,9 @@ package de.medizininformatikinitiative.flare.model.sq;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.JsonNode;
+import de.medizininformatikinitiative.flare.Either;
 import de.medizininformatikinitiative.flare.model.mapping.Mapping;
 import de.medizininformatikinitiative.flare.model.sq.expanded.ExpandedFilter;
-import reactor.core.publisher.Mono;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -40,7 +40,7 @@ public record AttributeFilter(TermCode code, FilterPart filterPart) implements F
     }
 
     @Override
-    public Mono<List<ExpandedFilter>> expand(LocalDate today, Mapping mapping) {
+    public Either<Exception, List<ExpandedFilter>> expand(LocalDate today, Mapping mapping) {
         return mapping.findAttributeMapping(code).flatMap(filterMapping -> filterPart.expand(today, filterMapping));
     }
 }

--- a/src/main/java/de/medizininformatikinitiative/flare/model/sq/ComparatorFilterPart.java
+++ b/src/main/java/de/medizininformatikinitiative/flare/model/sq/ComparatorFilterPart.java
@@ -1,10 +1,10 @@
 package de.medizininformatikinitiative.flare.model.sq;
 
+import de.medizininformatikinitiative.flare.Either;
 import de.medizininformatikinitiative.flare.model.mapping.FilterMapping;
 import de.medizininformatikinitiative.flare.model.sq.expanded.AgeUtils;
 import de.medizininformatikinitiative.flare.model.sq.expanded.ExpandedComparatorFilter;
 import de.medizininformatikinitiative.flare.model.sq.expanded.ExpandedFilter;
-import reactor.core.publisher.Mono;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -43,12 +43,12 @@ public record ComparatorFilterPart(Comparator comparator, BigDecimal value, Term
     }
 
     @Override
-    public Mono<List<ExpandedFilter>> expand(LocalDate today, FilterMapping filterMapping) {
+    public Either<Exception, List<ExpandedFilter>> expand(LocalDate today, FilterMapping filterMapping) {
         if (filterMapping.isAge()) {
             return unit == null
-                    ? Mono.error(new CalculationException("Missing unit in age calculation."))
+                    ? Either.left(new CalculationException("Missing unit in age calculation."))
                     : AgeUtils.expandedAgeFilterFromComparator(today, comparator, value, unit);
         }
-        return Mono.just(List.of(new ExpandedComparatorFilter(filterMapping.searchParameter(), comparator, value, unit)));
+        return Either.right(List.of(new ExpandedComparatorFilter(filterMapping.searchParameter(), comparator, value, unit)));
     }
 }

--- a/src/main/java/de/medizininformatikinitiative/flare/model/sq/ConceptFilterPart.java
+++ b/src/main/java/de/medizininformatikinitiative/flare/model/sq/ConceptFilterPart.java
@@ -1,10 +1,10 @@
 package de.medizininformatikinitiative.flare.model.sq;
 
+import de.medizininformatikinitiative.flare.Either;
 import de.medizininformatikinitiative.flare.model.mapping.FilterMapping;
 import de.medizininformatikinitiative.flare.model.sq.expanded.ExpandedCodeFilter;
 import de.medizininformatikinitiative.flare.model.sq.expanded.ExpandedConceptFilter;
 import de.medizininformatikinitiative.flare.model.sq.expanded.ExpandedFilter;
-import reactor.core.publisher.Mono;
 
 import java.time.LocalDate;
 import java.util.LinkedList;
@@ -34,8 +34,8 @@ public record ConceptFilterPart(List<TermCode> concepts) implements FilterPart {
     }
 
     @Override
-    public Mono<List<ExpandedFilter>> expand(LocalDate today, FilterMapping filterMapping) {
-        return Mono.just(concepts.stream()
+    public Either<Exception, List<ExpandedFilter>> expand(LocalDate today, FilterMapping filterMapping) {
+        return Either.right(concepts.stream()
                 .map(concept -> switch (filterMapping.type()) {
                     case CODE -> (ExpandedFilter) new ExpandedCodeFilter(filterMapping.searchParameter(),
                             concept.code());

--- a/src/main/java/de/medizininformatikinitiative/flare/model/sq/Filter.java
+++ b/src/main/java/de/medizininformatikinitiative/flare/model/sq/Filter.java
@@ -1,8 +1,8 @@
 package de.medizininformatikinitiative.flare.model.sq;
 
+import de.medizininformatikinitiative.flare.Either;
 import de.medizininformatikinitiative.flare.model.mapping.Mapping;
 import de.medizininformatikinitiative.flare.model.sq.expanded.ExpandedFilter;
-import reactor.core.publisher.Mono;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -19,5 +19,5 @@ public interface Filter {
      * @param mapping the mapping to use for expansion
      * @return possibly multiple expanded filters
      */
-    Mono<List<ExpandedFilter>> expand(LocalDate today, Mapping mapping);
+    Either<Exception, List<ExpandedFilter>> expand(LocalDate today, Mapping mapping);
 }

--- a/src/main/java/de/medizininformatikinitiative/flare/model/sq/FilterPart.java
+++ b/src/main/java/de/medizininformatikinitiative/flare/model/sq/FilterPart.java
@@ -2,9 +2,9 @@ package de.medizininformatikinitiative.flare.model.sq;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.JsonNode;
+import de.medizininformatikinitiative.flare.Either;
 import de.medizininformatikinitiative.flare.model.mapping.FilterMapping;
 import de.medizininformatikinitiative.flare.model.sq.expanded.ExpandedFilter;
-import reactor.core.publisher.Mono;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -62,5 +62,5 @@ public interface FilterPart {
         return new TermCode(system, unit.get("code").asText(), unit.get("display").asText());
     }
 
-    Mono<List<ExpandedFilter>> expand(LocalDate today, FilterMapping filterMapping);
+    Either<Exception, List<ExpandedFilter>> expand(LocalDate today, FilterMapping filterMapping);
 }

--- a/src/main/java/de/medizininformatikinitiative/flare/model/sq/RangeFilterPart.java
+++ b/src/main/java/de/medizininformatikinitiative/flare/model/sq/RangeFilterPart.java
@@ -1,10 +1,10 @@
 package de.medizininformatikinitiative.flare.model.sq;
 
+import de.medizininformatikinitiative.flare.Either;
 import de.medizininformatikinitiative.flare.model.mapping.FilterMapping;
 import de.medizininformatikinitiative.flare.model.sq.expanded.AgeUtils;
 import de.medizininformatikinitiative.flare.model.sq.expanded.ExpandedFilter;
 import de.medizininformatikinitiative.flare.model.sq.expanded.ExpandedRangeFilter;
-import reactor.core.publisher.Mono;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -28,10 +28,10 @@ public record RangeFilterPart(BigDecimal lowerBound, BigDecimal upperBound, Term
     }
 
     @Override
-    public Mono<List<ExpandedFilter>> expand(LocalDate today, FilterMapping filterMapping) {
+    public Either<Exception, List<ExpandedFilter>> expand(LocalDate today, FilterMapping filterMapping) {
         if (filterMapping.isAge()) {
             return AgeUtils.expandedAgeFilterFromRange(today, lowerBound, upperBound, unit);
         }
-        return Mono.just(List.of(new ExpandedRangeFilter(filterMapping.searchParameter(), lowerBound, upperBound, unit)));
+        return Either.right(List.of(new ExpandedRangeFilter(filterMapping.searchParameter(), lowerBound, upperBound, unit)));
     }
 }

--- a/src/main/java/de/medizininformatikinitiative/flare/model/sq/StructuredQuery.java
+++ b/src/main/java/de/medizininformatikinitiative/flare/model/sq/StructuredQuery.java
@@ -5,12 +5,14 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 import static java.util.Objects.requireNonNull;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record StructuredQuery(CriterionGroup<CriterionGroup<Criterion>> inclusionCriteria,
-                              CriterionGroup<CriterionGroup<Criterion>> exclusionCriteria) {
+                              Optional<CriterionGroup<CriterionGroup<Criterion>>> exclusionCriteria) {
 
     public StructuredQuery {
         requireNonNull(inclusionCriteria);
@@ -18,23 +20,45 @@ public record StructuredQuery(CriterionGroup<CriterionGroup<Criterion>> inclusio
     }
 
     public static StructuredQuery of(CriterionGroup<CriterionGroup<Criterion>> inclusionCriteria) {
-        return new StructuredQuery(inclusionCriteria, CriterionGroup.of(CriterionGroup.of()));
+        return new StructuredQuery(inclusionCriteria, Optional.empty());
     }
 
     public static StructuredQuery of(CriterionGroup<CriterionGroup<Criterion>> inclusionCriteria,
                                      CriterionGroup<CriterionGroup<Criterion>> exclusionCriteria) {
-        return new StructuredQuery(inclusionCriteria, exclusionCriteria);
+        return new StructuredQuery(inclusionCriteria, Optional.of(exclusionCriteria));
     }
 
     @JsonCreator
     public static StructuredQuery fromJson(@JsonProperty("inclusionCriteria") List<List<Criterion>> inclusionCriteria,
                                            @JsonProperty("exclusionCriteria") List<List<Criterion>> exclusionCriteria) {
-        if (inclusionCriteria.isEmpty() || inclusionCriteria.stream().allMatch(List::isEmpty)) {
+        if (inclusionCriteria == null) {
             throw new IllegalArgumentException("empty inclusion criteria");
         }
-        return new StructuredQuery(new CriterionGroup<>(inclusionCriteria.stream().map(CriterionGroup::new).toList()),
-                exclusionCriteria == null
-                        ? CriterionGroup.of(CriterionGroup.of())
-                        : new CriterionGroup<>(exclusionCriteria.stream().map(CriterionGroup::new).toList()));
+
+        var inclusionCriteriaGroups = inclusionCriteria.stream().flatMap(StructuredQuery::createCriterionGroup).toList();
+
+        if (inclusionCriteriaGroups.isEmpty()) {
+            throw new IllegalArgumentException("empty inclusion criteria");
+        }
+
+        var inclusionCriteriaGroup = new CriterionGroup<>(inclusionCriteriaGroups.get(0), inclusionCriteriaGroups.stream().skip(1).toList());
+
+        if (exclusionCriteria == null) {
+            return new StructuredQuery(inclusionCriteriaGroup, Optional.empty());
+        }
+
+        var exclusionCriteriaGroups = exclusionCriteria.stream().flatMap(StructuredQuery::createCriterionGroup).toList();
+
+        if (exclusionCriteriaGroups.isEmpty()) {
+            return new StructuredQuery(inclusionCriteriaGroup, Optional.empty());
+        }
+        return new StructuredQuery(inclusionCriteriaGroup, Optional.of(new CriterionGroup<>(exclusionCriteriaGroups.get(0),
+                exclusionCriteriaGroups.stream().skip(1).toList())));
+    }
+
+    private static Stream<CriterionGroup<Criterion>> createCriterionGroup(List<Criterion> criteria) {
+        return criteria == null || criteria.isEmpty()
+                ? Stream.empty()
+                : Stream.of(new CriterionGroup<>(criteria.get(0), criteria.stream().skip(1).toList()));
     }
 }

--- a/src/main/java/de/medizininformatikinitiative/flare/model/sq/TimeRestriction.java
+++ b/src/main/java/de/medizininformatikinitiative/flare/model/sq/TimeRestriction.java
@@ -2,11 +2,11 @@ package de.medizininformatikinitiative.flare.model.sq;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import de.medizininformatikinitiative.flare.Either;
 import de.medizininformatikinitiative.flare.model.mapping.Mapping;
 import de.medizininformatikinitiative.flare.model.sq.expanded.ExpandedDateComparatorFilter;
 import de.medizininformatikinitiative.flare.model.sq.expanded.ExpandedDateRangeFilter;
 import de.medizininformatikinitiative.flare.model.sq.expanded.ExpandedFilter;
-import reactor.core.publisher.Mono;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
@@ -47,8 +47,8 @@ public interface TimeRestriction extends Filter {
         }
 
         @Override
-        public Mono<List<ExpandedFilter>> expand(LocalDate today, Mapping mapping) {
-            return Mono.just(List.of(new ExpandedDateComparatorFilter(mapping.timeRestrictionParameter(), LESS_EQUAL, end)));
+        public Either<Exception, List<ExpandedFilter>> expand(LocalDate today, Mapping mapping) {
+            return Either.right(List.of(new ExpandedDateComparatorFilter(mapping.timeRestrictionParameter(), LESS_EQUAL, end)));
         }
     }
 
@@ -59,8 +59,8 @@ public interface TimeRestriction extends Filter {
         }
 
         @Override
-        public Mono<List<ExpandedFilter>> expand(LocalDate today, Mapping mapping) {
-            return Mono.just(List.of(new ExpandedDateComparatorFilter(mapping.timeRestrictionParameter(), GREATER_EQUAL, start)));
+        public Either<Exception, List<ExpandedFilter>> expand(LocalDate today, Mapping mapping) {
+            return Either.right(List.of(new ExpandedDateComparatorFilter(mapping.timeRestrictionParameter(), GREATER_EQUAL, start)));
         }
     }
 
@@ -72,8 +72,8 @@ public interface TimeRestriction extends Filter {
         }
 
         @Override
-        public Mono<List<ExpandedFilter>> expand(LocalDate today, Mapping mapping) {
-            return Mono.just(List.of(new ExpandedDateRangeFilter(mapping.timeRestrictionParameter(), start, end)));
+        public Either<Exception, List<ExpandedFilter>> expand(LocalDate today, Mapping mapping) {
+            return Either.right(List.of(new ExpandedDateRangeFilter(mapping.timeRestrictionParameter(), start, end)));
         }
     }
 }

--- a/src/main/java/de/medizininformatikinitiative/flare/model/sq/ValueFilter.java
+++ b/src/main/java/de/medizininformatikinitiative/flare/model/sq/ValueFilter.java
@@ -2,10 +2,10 @@ package de.medizininformatikinitiative.flare.model.sq;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.JsonNode;
+import de.medizininformatikinitiative.flare.Either;
 import de.medizininformatikinitiative.flare.model.mapping.Mapping;
 import de.medizininformatikinitiative.flare.model.mapping.ValueMappingNotFoundException;
 import de.medizininformatikinitiative.flare.model.sq.expanded.ExpandedFilter;
-import reactor.core.publisher.Mono;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
@@ -52,9 +52,9 @@ public record ValueFilter(FilterPart filterPart) implements Filter {
     }
 
     @Override
-    public Mono<List<ExpandedFilter>> expand(LocalDate today, Mapping mapping) {
+    public Either<Exception, List<ExpandedFilter>> expand(LocalDate today, Mapping mapping) {
         return mapping.valueFilterMapping()
                 .map(filterMapping -> filterPart.expand(today, filterMapping))
-                .orElseGet(() -> Mono.error(new ValueMappingNotFoundException(mapping.key())));
+                .orElseGet(() -> Either.left(new ValueMappingNotFoundException(mapping.key())));
     }
 }

--- a/src/main/java/de/medizininformatikinitiative/flare/model/sq/expanded/AgeUtils.java
+++ b/src/main/java/de/medizininformatikinitiative/flare/model/sq/expanded/AgeUtils.java
@@ -1,5 +1,6 @@
 package de.medizininformatikinitiative.flare.model.sq.expanded;
 
+import de.medizininformatikinitiative.flare.Either;
 import de.medizininformatikinitiative.flare.model.sq.CalculationException;
 import de.medizininformatikinitiative.flare.model.sq.Comparator;
 import de.medizininformatikinitiative.flare.model.sq.TermCode;
@@ -19,25 +20,25 @@ public class AgeUtils {
      * @param unit  the unit of the age value
      * @return a {@link Mono} containing either the birth date or an {@link CalculationException} if the unit is unknown
      */
-    private static Mono<LocalDate> birthDate(LocalDate today, BigDecimal age, TermCode unit) {
+    private static Either<Exception, LocalDate> birthDate(LocalDate today, BigDecimal age, TermCode unit) {
         return switch (unit.code()) {
-            case "a" -> Mono.just(today.minusYears(age.intValue()));
-            case "mo" -> Mono.just(today.minusMonths(age.intValue()));
-            case "wk" -> Mono.just(today.minusWeeks(age.intValue()));
-            default -> Mono.error(new CalculationException("Unknown age unit `%s`.".formatted(unit.code())));
+            case "a" -> Either.right(today.minusYears(age.intValue()));
+            case "mo" -> Either.right(today.minusMonths(age.intValue()));
+            case "wk" -> Either.right(today.minusWeeks(age.intValue()));
+            default -> Either.left(new CalculationException("Unknown age unit `%s`.".formatted(unit.code())));
         };
     }
 
-    private static Mono<LocalDate> equalCaseLowerDate(LocalDate today, BigDecimal age, TermCode unit) {
+    private static Either<Exception, LocalDate> equalCaseLowerDate(LocalDate today, BigDecimal age, TermCode unit) {
         return birthDate(today, age.add(BigDecimal.ONE), unit).map(date -> date.plusDays(1));
     }
 
-    private static Mono<LocalDate> equalCaseUpperDate(LocalDate today, BigDecimal age, TermCode unit) {
+    private static Either<Exception, LocalDate> equalCaseUpperDate(LocalDate today, BigDecimal age, TermCode unit) {
         return birthDate(today, age, unit);
     }
 
-    public static Mono<List<ExpandedFilter>> expandedAgeFilterFromComparator(LocalDate today, Comparator comparator,
-                                                                             BigDecimal age, TermCode unit) {
+    public static Either<Exception, List<ExpandedFilter>> expandedAgeFilterFromComparator(LocalDate today, Comparator comparator,
+                                                                                          BigDecimal age, TermCode unit) {
         if (comparator.equals(Comparator.EQUAL)) {
             return equalCaseLowerDate(today, age, unit)
                     .flatMap(lowerBound -> equalCaseUpperDate(today, age, unit)
@@ -48,8 +49,8 @@ public class AgeUtils {
         }
     }
 
-    public static Mono<List<ExpandedFilter>> expandedAgeFilterFromRange(LocalDate today, BigDecimal ageLowerBound,
-                                                                        BigDecimal ageUpperBound, TermCode unit) {
+    public static Either<Exception, List<ExpandedFilter>> expandedAgeFilterFromRange(LocalDate today, BigDecimal ageLowerBound,
+                                                                                     BigDecimal ageUpperBound, TermCode unit) {
         return birthDate(today, ageLowerBound, unit).flatMap(upperBoundDate -> birthDate(today, ageUpperBound, unit)
                 .map(lowerBoundDate -> List.of(new ExpandedDateRangeFilter("birthdate", lowerBoundDate, upperBoundDate))));
     }

--- a/src/main/java/de/medizininformatikinitiative/flare/model/translate/Expression.java
+++ b/src/main/java/de/medizininformatikinitiative/flare/model/translate/Expression.java
@@ -8,12 +8,4 @@ import de.medizininformatikinitiative.flare.service.StructuredQueryService;
  * the query execution.
  */
 public interface Expression {
-
-    /**
-     * Returns {@code true} iff the expression is empty and so can be removed from a bigger expression without changing
-     * the meaning.
-     *
-     * @return {@code true} iff the expression is empty
-     */
-    boolean isEmpty();
 }

--- a/src/main/java/de/medizininformatikinitiative/flare/model/translate/QueryExpression.java
+++ b/src/main/java/de/medizininformatikinitiative/flare/model/translate/QueryExpression.java
@@ -17,16 +17,6 @@ public record QueryExpression(Query query) implements Expression {
     }
 
     /**
-     * Returns always {@code false}, because query expressions are never empty.
-     *
-     * @return always {@code false}
-     */
-    @Override
-    public boolean isEmpty() {
-        return false;
-    }
-
-    /**
      * The JSON value of a query expression is just the query string.
      *
      * @return a string representation of this query expression.

--- a/src/main/java/de/medizininformatikinitiative/flare/rest/QueryController.java
+++ b/src/main/java/de/medizininformatikinitiative/flare/rest/QueryController.java
@@ -1,5 +1,6 @@
 package de.medizininformatikinitiative.flare.rest;
 
+import de.medizininformatikinitiative.Monos;
 import de.medizininformatikinitiative.flare.model.mapping.MappingException;
 import de.medizininformatikinitiative.flare.model.sq.StructuredQuery;
 import de.medizininformatikinitiative.flare.service.StructuredQueryService;
@@ -58,7 +59,8 @@ public class QueryController {
     public Mono<ServerResponse> translate(ServerRequest request) {
         logger.debug("Translate query");
         return request.bodyToMono(StructuredQuery.class)
-                .flatMap(queryService::translate)
+                .map(queryService::translate)
+                .flatMap(Monos::ofEither)
                 .flatMap(queryExpression -> ok().bodyValue(queryExpression))
                 .onErrorResume(MappingException.class, e -> badRequest().bodyValue(new Error(e.getMessage())));
     }

--- a/src/main/java/de/medizininformatikinitiative/flare/service/Translator.java
+++ b/src/main/java/de/medizininformatikinitiative/flare/service/Translator.java
@@ -1,11 +1,11 @@
 package de.medizininformatikinitiative.flare.service;
 
+import de.medizininformatikinitiative.flare.Either;
 import de.medizininformatikinitiative.flare.model.fhir.Query;
 import de.medizininformatikinitiative.flare.model.mapping.MappingContext;
 import de.medizininformatikinitiative.flare.model.sq.Criterion;
 import de.medizininformatikinitiative.flare.model.sq.expanded.ExpandedCriterion;
 import org.springframework.stereotype.Component;
-import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.Objects;
@@ -19,7 +19,7 @@ public class Translator {
         this.mappingContext = Objects.requireNonNull(mappingContext);
     }
 
-    public Mono<List<Query>> toQuery(Criterion criterion) {
+    public Either<Exception, List<Query>> toQuery(Criterion criterion) {
         return criterion.expand(mappingContext)
                 .map(expandedCriteria -> expandedCriteria.stream().map(ExpandedCriterion::toQuery).toList());
     }

--- a/src/test/java/de/medizininformatikinitiative/MonosTest.java
+++ b/src/test/java/de/medizininformatikinitiative/MonosTest.java
@@ -1,0 +1,34 @@
+package de.medizininformatikinitiative;
+
+import de.medizininformatikinitiative.flare.Either;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import reactor.test.StepVerifier;
+
+class MonosTest {
+
+    public static final String MESSAGE = "msg-150857";
+    public static final String VALUE = "val-151510";
+
+    @Nested
+    @DisplayName("ofEither")
+    class OfEither {
+
+        @Test
+        @DisplayName("a Left Either results in an Error Mono ")
+        void ofLeft() {
+            var result = Monos.ofEither(Either.left(new Exception(MESSAGE)));
+
+            StepVerifier.create(result).expectErrorMessage(MESSAGE).verify();
+        }
+
+        @Test
+        @DisplayName("a Right Either results in an Success Mono ")
+        void ofRight() {
+            var result = Monos.ofEither(Either.right(VALUE));
+
+            StepVerifier.create(result).expectNext(VALUE).verifyComplete();
+        }
+    }
+}

--- a/src/test/java/de/medizininformatikinitiative/flare/Assertions.java
+++ b/src/test/java/de/medizininformatikinitiative/flare/Assertions.java
@@ -1,0 +1,8 @@
+package de.medizininformatikinitiative.flare;
+
+public interface Assertions {
+
+    static <L, R> EitherAssert<L, R> assertThat(Either<L, R> actual) {
+        return new EitherAssert<>(actual);
+    }
+}

--- a/src/test/java/de/medizininformatikinitiative/flare/EitherAssert.java
+++ b/src/test/java/de/medizininformatikinitiative/flare/EitherAssert.java
@@ -1,0 +1,59 @@
+package de.medizininformatikinitiative.flare;
+
+import org.assertj.core.api.AbstractAssert;
+
+import java.util.function.Consumer;
+
+public class EitherAssert<L, R> extends AbstractAssert<EitherAssert<L, R>, Either<L, R>> {
+
+    protected EitherAssert(Either<L, R> actual) {
+        super(actual, EitherAssert.class);
+    }
+
+    public EitherAssert<L, R> isLeftInstanceOf(Class<?> clazz) {
+        isNotNull();
+        if (actual instanceof Either.Left<L, R> l) {
+            if (!clazz.isInstance(l.val())) {
+                failWithMessage("Expected either to be left and instanceof `%s` but was a `%s`.", clazz.getName(),
+                        l.val().getClass().getName());
+            }
+        } else {
+            failWithMessage("Expected either to be left but was right.");
+        }
+        return myself;
+    }
+
+    public EitherAssert<L, R> isLeftEqualTo(L expected) {
+        isNotNull();
+        if (actual instanceof Either.Left<L, R> l) {
+            if (!l.val().equals(expected)) {
+                failWithMessage("Expected either to be left with value `%s` but was `%s`.", expected, l.val());
+            }
+        } else {
+            failWithMessage("Expected either to be left but was left.");
+        }
+        return myself;
+    }
+
+    public EitherAssert<L, R> isRightEqualTo(R expected) {
+        isNotNull();
+        if (actual instanceof Either.Right<L, R> r) {
+            if (!r.val().equals(expected)) {
+                failWithMessage("Expected either to be right with value `%s` but was `%s`.", expected, r.val());
+            }
+        } else {
+            failWithMessage("Expected either to be right but was left.");
+        }
+        return myself;
+    }
+
+    public EitherAssert<L, R> isRightSatisfying(Consumer<R> requirement) {
+        isNotNull();
+        if (actual instanceof Either.Right<L, R> r) {
+            requirement.accept(r.val());
+        } else {
+            failWithMessage("Expected either to be right but was left.");
+        }
+        return myself;
+    }
+}

--- a/src/test/java/de/medizininformatikinitiative/flare/EitherTest.java
+++ b/src/test/java/de/medizininformatikinitiative/flare/EitherTest.java
@@ -1,0 +1,175 @@
+package de.medizininformatikinitiative.flare;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static de.medizininformatikinitiative.flare.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EitherTest {
+
+    @Test
+    @DisplayName("creating a left Either")
+    void left() {
+        assertThat(Either.left("foo")).isLeftEqualTo("foo");
+    }
+
+    @Test
+    @DisplayName("creating a right Either")
+    void right() {
+        assertThat(Either.right("foo")).isRightEqualTo("foo");
+    }
+
+    @Nested
+    @DisplayName("lift")
+    class Lift {
+
+        @Test
+        @DisplayName("two right operands result in a right result")
+        void bothRight() {
+            var result = Either.lift(Integer::signum).apply(Either.right(1));
+
+            assertThat(result).isRightEqualTo(1);
+        }
+
+        @Test
+        @DisplayName("left operand results in a left result")
+        void firstLeft() {
+            var result = Either.lift(Integer::signum).apply(Either.left("error"));
+
+            assertThat(result).isLeftEqualTo("error");
+        }
+    }
+
+    @Nested
+    @DisplayName("lift2")
+    class Lift2 {
+
+        @Test
+        @DisplayName("two right operands result in a right result")
+        void bothRight() {
+            var result = Either.lift2(List::of).apply(Either.right(1), Either.right(2));
+
+            assertThat(result).isRightEqualTo(List.of(1, 2));
+        }
+
+        @Test
+        @DisplayName("first left operand results in a left result")
+        void firstLeft() {
+            var result = Either.lift2(List::of).apply(Either.left("error"), Either.right(2));
+
+            assertThat(result).isLeftEqualTo("error");
+        }
+
+        @Test
+        @DisplayName("second left operand results in a left result")
+        void secondLeft() {
+            var result = Either.lift2(List::of).apply(Either.right(List.of(1)), Either.left("error"));
+
+            assertThat(result).isLeftEqualTo("error");
+        }
+    }
+
+    @Nested
+    @DisplayName("liftBinOp")
+    class LiftBinOp {
+
+        @Test
+        @DisplayName("two right operands result in a right result")
+        void bothRight() {
+            var result = Either.liftBinOp(Integer::sum).apply(Either.right(1), Either.right(2));
+
+            assertThat(result).isRightEqualTo(3);
+        }
+
+        @Test
+        @DisplayName("first left operand results in a left result")
+        void firstLeft() {
+            var result = Either.liftBinOp(Integer::sum).apply(Either.left("error"), Either.right(2));
+
+            assertThat(result).isLeftEqualTo("error");
+        }
+
+        @Test
+        @DisplayName("second left operand results in a left result")
+        void secondLeft() {
+            var result = Either.liftBinOp(Integer::sum).apply(Either.right(1), Either.left("error"));
+
+            assertThat(result).isLeftEqualTo("error");
+        }
+    }
+
+    @Nested
+    @DisplayName("map")
+    class Map {
+
+        @Test
+        @DisplayName("a right value is mapped")
+        void rightValue() {
+            var result = Either.right(1).map(x -> x + 1);
+
+            assertThat(result).isRightEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("a left value is not mapped")
+        void leftValue() {
+            var result = Either.<Integer, Integer>left(1).map(x -> x + 1);
+
+            assertThat(result).isLeftEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("flatMap")
+    class FlatMap {
+
+        @Test
+        @DisplayName("a right value is mapped by a function returning a right value")
+        void rightValueRight() {
+            var result = Either.right(1).flatMap(x -> Either.right(x + 1));
+
+            assertThat(result).isRightEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("a right value is mapped by a function returning a left value")
+        void rightValueLeft() {
+            var result = Either.right(1).flatMap(x -> Either.left(x + 1));
+
+            assertThat(result).isLeftEqualTo(2);
+        }
+
+        @Test
+        @DisplayName("a left value is not mapped")
+        void leftValue() {
+            var result = Either.<Integer, Integer>left(1).flatMap(x -> Either.right(x + 1));
+
+            assertThat(result).isLeftEqualTo(1);
+        }
+    }
+
+    @Nested
+    @DisplayName("either")
+    class EitherMethod {
+
+        @Test
+        @DisplayName("a right value is applied to the right mapper")
+        void right() {
+            var result = Either.<Exception, String>right("a").either(Exception::getMessage, x -> x + "b");
+
+            assertThat(result).isEqualTo("ab");
+        }
+
+        @Test
+        @DisplayName("a left value is applied to the left mapper")
+        void left() {
+            var result = Either.<Exception, String>left(new Exception("a")).either(Exception::getMessage, x -> x + "b");
+
+            assertThat(result).isEqualTo("a");
+        }
+    }
+}

--- a/src/test/java/de/medizininformatikinitiative/flare/model/sq/StructuredQueryTest.java
+++ b/src/test/java/de/medizininformatikinitiative/flare/model/sq/StructuredQueryTest.java
@@ -5,14 +5,57 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class StructuredQueryTest {
 
     static final TermCode C71 = TermCode.of("http://fhir.de/CodeSystem/bfarm/icd-10-gm", "C71",
             "Malignant neoplasm of brain");
 
+    static final TermCode C72 = TermCode.of("http://fhir.de/CodeSystem/bfarm/icd-10-gm", "C72",
+            "Malignant neoplasm of brain");
+
+    static final TermCode C73 = TermCode.of("http://fhir.de/CodeSystem/bfarm/icd-10-gm", "C73",
+            "Malignant neoplasm of brain");
+
     @Test
-    void deserializeJson() throws JsonProcessingException {
+    void deserializeJson_Empty() {
+        var s = "{}";
+
+        assertThatThrownBy(() -> new ObjectMapper().readValue(s, StructuredQuery.class))
+                .hasRootCauseMessage("empty inclusion criteria");
+    }
+
+    @Test
+    void deserializeJson_EmptyInclusionCriteria() {
+        var s = """
+                {
+                  "inclusionCriteria": [
+                  ]
+                }
+                """;
+
+        assertThatThrownBy(() -> new ObjectMapper().readValue(s, StructuredQuery.class))
+                .hasRootCauseMessage("empty inclusion criteria");
+    }
+
+    @Test
+    void deserializeJson_EmptyInclusionCriteria2() {
+        var s = """
+                {
+                  "inclusionCriteria": [
+                    [
+                    ]
+                  ]
+                }
+                """;
+
+        assertThatThrownBy(() -> new ObjectMapper().readValue(s, StructuredQuery.class))
+                .hasRootCauseMessage("empty inclusion criteria");
+    }
+
+    @Test
+    void deserializeJson_OneInclusionCriteria() throws JsonProcessingException {
         var s = """
                 {
                   "inclusionCriteria": [
@@ -34,5 +77,248 @@ class StructuredQueryTest {
         var query = new ObjectMapper().readValue(s, StructuredQuery.class);
 
         assertThat(query).isEqualTo(StructuredQuery.of(CriterionGroup.of(CriterionGroup.of(Criterion.of(Concept.of(C71))))));
+    }
+
+    @Test
+    void deserializeJson_TwoInclusionCriteria() throws JsonProcessingException {
+        var s = """
+                {
+                  "inclusionCriteria": [
+                    [
+                      {
+                        "termCodes": [
+                          {
+                            "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
+                            "code": "C71",
+                            "display": "Malignant neoplasm of brain"
+                          }
+                        ]
+                      },
+                      {
+                        "termCodes": [
+                          {
+                            "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
+                            "code": "C72",
+                            "display": "Malignant neoplasm of brain"
+                          }
+                        ]
+                      }
+                    ]
+                  ]
+                }
+                """;
+
+        var query = new ObjectMapper().readValue(s, StructuredQuery.class);
+
+        assertThat(query).isEqualTo(StructuredQuery.of(CriterionGroup.of(CriterionGroup.of(Criterion.of(Concept.of(C71)),
+                Criterion.of(Concept.of(C72))))));
+    }
+
+    @Test
+    void deserializeJson_TwoInclusionCriteria2() throws JsonProcessingException {
+        var s = """
+                {
+                  "inclusionCriteria": [
+                    [
+                      {
+                        "termCodes": [
+                          {
+                            "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
+                            "code": "C71",
+                            "display": "Malignant neoplasm of brain"
+                          }
+                        ]
+                      }
+                    ],
+                    [
+                      {
+                        "termCodes": [
+                          {
+                            "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
+                            "code": "C72",
+                            "display": "Malignant neoplasm of brain"
+                          }
+                        ]
+                      }
+                    ]
+                  ]
+                }
+                """;
+
+        var query = new ObjectMapper().readValue(s, StructuredQuery.class);
+
+        assertThat(query).isEqualTo(StructuredQuery.of(CriterionGroup.of(CriterionGroup.of(Criterion.of(Concept.of(C71))),
+                CriterionGroup.of(Criterion.of(Concept.of(C72))))));
+    }
+
+    @Test
+    void deserializeJson_EmptyInclusionCriteriaAreIgnored() throws JsonProcessingException {
+        var s = """
+                {
+                  "inclusionCriteria": [
+                    [
+                      {
+                        "termCodes": [
+                          {
+                            "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
+                            "code": "C71",
+                            "display": "Malignant neoplasm of brain"
+                          }
+                        ]
+                      }
+                    ],
+                    [
+                    ]
+                  ]
+                }
+                """;
+
+        var query = new ObjectMapper().readValue(s, StructuredQuery.class);
+
+        assertThat(query).isEqualTo(StructuredQuery.of(CriterionGroup.of(CriterionGroup.of(Criterion.of(Concept.of(C71))))));
+    }
+
+    @Test
+    void deserializeJson_OneExclusionCriteria() throws JsonProcessingException {
+        var s = """
+                {
+                  "inclusionCriteria": [
+                    [
+                      {
+                        "termCodes": [
+                          {
+                            "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
+                            "code": "C71",
+                            "display": "Malignant neoplasm of brain"
+                          }
+                        ]
+                      }
+                    ]
+                  ],
+                  "exclusionCriteria": [
+                    [
+                      {
+                        "termCodes": [
+                          {
+                            "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
+                            "code": "C72",
+                            "display": "Malignant neoplasm of brain"
+                          }
+                        ]
+                      }
+                    ]
+                  ]
+                }
+                """;
+
+        var query = new ObjectMapper().readValue(s, StructuredQuery.class);
+
+        assertThat(query).isEqualTo(StructuredQuery.of(
+                CriterionGroup.of(CriterionGroup.of(Criterion.of(Concept.of(C71)))),
+                CriterionGroup.of(CriterionGroup.of(Criterion.of(Concept.of(C72))))
+        ));
+    }
+
+    @Test
+    void deserializeJson_TwoExclusionCriteria() throws JsonProcessingException {
+        var s = """
+                {
+                  "inclusionCriteria": [
+                    [
+                      {
+                        "termCodes": [
+                          {
+                            "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
+                            "code": "C71",
+                            "display": "Malignant neoplasm of brain"
+                          }
+                        ]
+                      }
+                    ]
+                  ],
+                  "exclusionCriteria": [
+                    [
+                      {
+                        "termCodes": [
+                          {
+                            "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
+                            "code": "C72",
+                            "display": "Malignant neoplasm of brain"
+                          }
+                        ]
+                      },
+                      {
+                        "termCodes": [
+                          {
+                            "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
+                            "code": "C73",
+                            "display": "Malignant neoplasm of brain"
+                          }
+                        ]
+                      }
+                    ]
+                  ]
+                }
+                """;
+
+        var query = new ObjectMapper().readValue(s, StructuredQuery.class);
+
+        assertThat(query).isEqualTo(StructuredQuery.of(
+                CriterionGroup.of(CriterionGroup.of(Criterion.of(Concept.of(C71)))),
+                CriterionGroup.of(CriterionGroup.of(Criterion.of(Concept.of(C72)), Criterion.of(Concept.of(C73))))
+        ));
+    }
+
+    @Test
+    void deserializeJson_TwoExclusionCriteria2() throws JsonProcessingException {
+        var s = """
+                {
+                  "inclusionCriteria": [
+                    [
+                      {
+                        "termCodes": [
+                          {
+                            "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
+                            "code": "C71",
+                            "display": "Malignant neoplasm of brain"
+                          }
+                        ]
+                      }
+                    ]
+                  ],
+                  "exclusionCriteria": [
+                    [
+                      {
+                        "termCodes": [
+                          {
+                            "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
+                            "code": "C72",
+                            "display": "Malignant neoplasm of brain"
+                          }
+                        ]
+                      }
+                    ],
+                    [
+                      {
+                        "termCodes": [
+                          {
+                            "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
+                            "code": "C73",
+                            "display": "Malignant neoplasm of brain"
+                          }
+                        ]
+                      }
+                    ]
+                  ]
+                }
+                """;
+
+        var query = new ObjectMapper().readValue(s, StructuredQuery.class);
+
+        assertThat(query).isEqualTo(StructuredQuery.of(
+                CriterionGroup.of(CriterionGroup.of(Criterion.of(Concept.of(C71)))),
+                CriterionGroup.of(CriterionGroup.of(Criterion.of(Concept.of(C72))),
+                        CriterionGroup.of(Criterion.of(Concept.of(C73))))
+        ));
     }
 }

--- a/src/test/java/de/medizininformatikinitiative/flare/model/translate/OperatorTest.java
+++ b/src/test/java/de/medizininformatikinitiative/flare/model/translate/OperatorTest.java
@@ -10,34 +10,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class OperatorTest {
 
     @Test
-    void isEmpty_NoOperands() {
-        var operator = Operator.union();
-
-        assertThat(operator.isEmpty()).isTrue();
-    }
-
-    @Test
-    void isEmpty_OneEmptyOperand() {
-        var operator = Operator.union(Operator.intersection());
-
-        assertThat(operator.isEmpty()).isTrue();
-    }
-
-    @Test
-    void isEmpty_OneNonEmptyOperand() {
-        var operator = Operator.union(new QueryExpression(Query.ofType("Condition")));
-
-        assertThat(operator.isEmpty()).isFalse();
-    }
-
-    @Test
-    void isEmpty_OneEmptyFollowedByOneNonEmptyOperand() {
-        var operator = Operator.union(Operator.intersection(), new QueryExpression(Query.ofType("Condition")));
-
-        assertThat(operator.isEmpty()).isFalse();
-    }
-
-    @Test
     void serializeJson() throws JsonProcessingException {
         var operator = Operator.union(new QueryExpression(Query.ofType("Condition")));
 

--- a/src/test/java/de/medizininformatikinitiative/flare/model/translate/QueryExpressionTest.java
+++ b/src/test/java/de/medizininformatikinitiative/flare/model/translate/QueryExpressionTest.java
@@ -10,13 +10,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 class QueryExpressionTest {
 
     @Test
-    void isNotEmpty() {
-        var expression = new QueryExpression(Query.ofType("Condition"));
-
-        assertThat(expression.isEmpty()).isFalse();
-    }
-
-    @Test
     void serializeJson() throws JsonProcessingException {
         var expression = new QueryExpression(Query.ofType("Condition"));
 

--- a/src/test/java/de/medizininformatikinitiative/flare/rest/QueryControllerTest.java
+++ b/src/test/java/de/medizininformatikinitiative/flare/rest/QueryControllerTest.java
@@ -1,5 +1,6 @@
 package de.medizininformatikinitiative.flare.rest;
 
+import de.medizininformatikinitiative.flare.Either;
 import de.medizininformatikinitiative.flare.model.fhir.Query;
 import de.medizininformatikinitiative.flare.model.mapping.MappingNotFoundException;
 import de.medizininformatikinitiative.flare.model.sq.*;
@@ -101,7 +102,7 @@ class QueryControllerTest {
 
     @Test
     void translate() {
-        when(queryService.translate(STRUCTURED_QUERY)).thenReturn(Mono.just(Operator.difference(QUERY_EXPRESSION)));
+        when(queryService.translate(STRUCTURED_QUERY)).thenReturn(Either.right(Operator.union(QUERY_EXPRESSION)));
 
         client.post()
                 .uri("/query/translate")
@@ -126,13 +127,13 @@ class QueryControllerTest {
                 .exchange()
                 .expectStatus().isOk()
                 .expectBody()
-                .jsonPath("$.name").isEqualTo("difference")
+                .jsonPath("$.name").isEqualTo("union")
                 .jsonPath("$.operands[0]").isEqualTo("[base]/Condition");
     }
 
     @Test
     void translate_error() {
-        when(queryService.translate(STRUCTURED_QUERY)).thenReturn(Mono.error(new MappingNotFoundException(FEVER)));
+        when(queryService.translate(STRUCTURED_QUERY)).thenReturn(Either.left(new MappingNotFoundException(FEVER)));
 
         client.post()
                 .uri("/query/translate")

--- a/src/test/java/de/medizininformatikinitiative/flare/service/StructuredQueryServiceTest.java
+++ b/src/test/java/de/medizininformatikinitiative/flare/service/StructuredQueryServiceTest.java
@@ -1,5 +1,6 @@
 package de.medizininformatikinitiative.flare.service;
 
+import de.medizininformatikinitiative.flare.Either;
 import de.medizininformatikinitiative.flare.model.Population;
 import de.medizininformatikinitiative.flare.model.fhir.Query;
 import de.medizininformatikinitiative.flare.model.fhir.QueryParams;
@@ -17,6 +18,7 @@ import reactor.test.StepVerifier;
 
 import java.util.List;
 
+import static de.medizininformatikinitiative.flare.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
@@ -49,18 +51,9 @@ class StructuredQueryServiceTest {
     private StructuredQueryService service;
 
     @Test
-    void execute_emptyQuery() {
-        var query = StructuredQuery.of(CriterionGroup.of(CriterionGroup.of()));
-
-        var result = service.execute(query).block();
-
-        assertThat(result).isZero();
-    }
-
-    @Test
     void execute_singleIncludeConceptCriterion_WithMappingError() {
         var query = StructuredQuery.of(CriterionGroup.of(CriterionGroup.of(CONCEPT_CRITERION)));
-        when(translator.toQuery(CONCEPT_CRITERION)).thenReturn(Mono.error(new MappingNotFoundException(C71)));
+        when(translator.toQuery(CONCEPT_CRITERION)).thenReturn(Either.left(new MappingNotFoundException(C71)));
 
         var result = service.execute(query);
 
@@ -70,17 +63,17 @@ class StructuredQueryServiceTest {
     @Test
     void translate_singleIncludeConceptCriterion_WithMappingError() {
         var query = StructuredQuery.of(CriterionGroup.of(CriterionGroup.of(CONCEPT_CRITERION)));
-        when(translator.toQuery(CONCEPT_CRITERION)).thenReturn(Mono.error(new MappingNotFoundException(C71)));
+        when(translator.toQuery(CONCEPT_CRITERION)).thenReturn(Either.left(new MappingNotFoundException(C71)));
 
         var result = service.translate(query);
 
-        StepVerifier.create(result).expectError(MappingNotFoundException.class).verify();
+        assertThat(result).isLeftInstanceOf(MappingNotFoundException.class);
     }
 
     @Test
     void execute_singleIncludeConceptCriterion() {
         var query = StructuredQuery.of(CriterionGroup.of(CriterionGroup.of(CONCEPT_CRITERION)));
-        when(translator.toQuery(CONCEPT_CRITERION)).thenReturn(Mono.just(List.of(CONCEPT_QUERY)));
+        when(translator.toQuery(CONCEPT_CRITERION)).thenReturn(Either.right(List.of(CONCEPT_QUERY)));
         when(fhirQueryService.execute(CONCEPT_QUERY)).thenReturn(Mono.just(Population.of(PATIENT_ID)));
 
         var result = service.execute(query).block();
@@ -91,17 +84,17 @@ class StructuredQueryServiceTest {
     @Test
     void translate_singleIncludeConceptCriterion() {
         var query = StructuredQuery.of(CriterionGroup.of(CriterionGroup.of(CONCEPT_CRITERION)));
-        when(translator.toQuery(CONCEPT_CRITERION)).thenReturn(Mono.just(List.of(CONCEPT_QUERY)));
+        when(translator.toQuery(CONCEPT_CRITERION)).thenReturn(Either.right(List.of(CONCEPT_QUERY)));
 
-        var result = service.translate(query).block();
+        var result = service.translate(query);
 
-        assertThat(result).isEqualTo(Operator.intersection(Operator.union(new QueryExpression(CONCEPT_QUERY))));
+        assertThat(result).isRightEqualTo(Operator.intersection(Operator.union(new QueryExpression(CONCEPT_QUERY))));
     }
 
     @Test
     void execute_singleIncludeConceptCriterion_Expanding() {
         var query = StructuredQuery.of(CriterionGroup.of(CriterionGroup.of(CONCEPT_CRITERION)));
-        when(translator.toQuery(CONCEPT_CRITERION)).thenReturn(Mono.just(List.of(CONCEPT_QUERY_1, CONCEPT_QUERY_2)));
+        when(translator.toQuery(CONCEPT_CRITERION)).thenReturn(Either.right(List.of(CONCEPT_QUERY_1, CONCEPT_QUERY_2)));
         when(fhirQueryService.execute(CONCEPT_QUERY_1)).thenReturn(Mono.just(Population.of(PATIENT_ID_1)));
         when(fhirQueryService.execute(CONCEPT_QUERY_2)).thenReturn(Mono.just(Population.of(PATIENT_ID_2)));
 
@@ -113,18 +106,18 @@ class StructuredQueryServiceTest {
     @Test
     void translate_singleIncludeConceptCriterion_Expanding() {
         var query = StructuredQuery.of(CriterionGroup.of(CriterionGroup.of(CONCEPT_CRITERION)));
-        when(translator.toQuery(CONCEPT_CRITERION)).thenReturn(Mono.just(List.of(CONCEPT_QUERY_1, CONCEPT_QUERY_2)));
+        when(translator.toQuery(CONCEPT_CRITERION)).thenReturn(Either.right(List.of(CONCEPT_QUERY_1, CONCEPT_QUERY_2)));
 
-        var result = service.translate(query).block();
+        var result = service.translate(query);
 
-        assertThat(result).isEqualTo(Operator.intersection(Operator.union(new QueryExpression(CONCEPT_QUERY_1),
+        assertThat(result).isRightEqualTo(Operator.intersection(Operator.union(new QueryExpression(CONCEPT_QUERY_1),
                 new QueryExpression(CONCEPT_QUERY_2))));
     }
 
     @Test
     void execute_singleIncludeConceptCriterion_Expanding_SamePatient() {
         var query = StructuredQuery.of(CriterionGroup.of(CriterionGroup.of(CONCEPT_CRITERION)));
-        when(translator.toQuery(CONCEPT_CRITERION)).thenReturn(Mono.just(List.of(CONCEPT_QUERY_1, CONCEPT_QUERY_2)));
+        when(translator.toQuery(CONCEPT_CRITERION)).thenReturn(Either.right(List.of(CONCEPT_QUERY_1, CONCEPT_QUERY_2)));
         when(fhirQueryService.execute(CONCEPT_QUERY_1)).thenReturn(Mono.just(Population.of(PATIENT_ID)));
         when(fhirQueryService.execute(CONCEPT_QUERY_2)).thenReturn(Mono.just(Population.of(PATIENT_ID)));
 
@@ -136,7 +129,7 @@ class StructuredQueryServiceTest {
     @Test
     void execute_same_singleIncludeConceptCriterion_singleExcludeConceptCriterion() {
         var query = StructuredQuery.of(CriterionGroup.of(CriterionGroup.of(CONCEPT_CRITERION)), CriterionGroup.of(CriterionGroup.of(CONCEPT_CRITERION)));
-        when(translator.toQuery(CONCEPT_CRITERION)).thenReturn(Mono.just(List.of(CONCEPT_QUERY)));
+        when(translator.toQuery(CONCEPT_CRITERION)).thenReturn(Either.right(List.of(CONCEPT_QUERY)));
         when(fhirQueryService.execute(CONCEPT_QUERY)).thenReturn(Mono.just(Population.of(PATIENT_ID)));
 
         var result = service.execute(query).block();
@@ -147,8 +140,8 @@ class StructuredQueryServiceTest {
     @Test
     void execute_singleIncludeConceptCriterion_singleExcludeConceptCriterion_SamePatient() {
         var query = StructuredQuery.of(CriterionGroup.of(CriterionGroup.of(CONCEPT_CRITERION_1)), CriterionGroup.of(CriterionGroup.of(CONCEPT_CRITERION_2)));
-        when(translator.toQuery(CONCEPT_CRITERION_1)).thenReturn(Mono.just(List.of(CONCEPT_QUERY_1)));
-        when(translator.toQuery(CONCEPT_CRITERION_2)).thenReturn(Mono.just(List.of(CONCEPT_QUERY_2)));
+        when(translator.toQuery(CONCEPT_CRITERION_1)).thenReturn(Either.right(List.of(CONCEPT_QUERY_1)));
+        when(translator.toQuery(CONCEPT_CRITERION_2)).thenReturn(Either.right(List.of(CONCEPT_QUERY_2)));
         when(fhirQueryService.execute(CONCEPT_QUERY_1)).thenReturn(Mono.just(Population.of(PATIENT_ID)));
         when(fhirQueryService.execute(CONCEPT_QUERY_2)).thenReturn(Mono.just(Population.of(PATIENT_ID)));
 
@@ -160,12 +153,12 @@ class StructuredQueryServiceTest {
     @Test
     void translate_singleIncludeConceptCriterion_singleExcludeConceptCriterion() {
         var query = StructuredQuery.of(CriterionGroup.of(CriterionGroup.of(CONCEPT_CRITERION_1)), CriterionGroup.of(CriterionGroup.of(CONCEPT_CRITERION_2)));
-        when(translator.toQuery(CONCEPT_CRITERION_1)).thenReturn(Mono.just(List.of(CONCEPT_QUERY_1)));
-        when(translator.toQuery(CONCEPT_CRITERION_2)).thenReturn(Mono.just(List.of(CONCEPT_QUERY_2)));
+        when(translator.toQuery(CONCEPT_CRITERION_1)).thenReturn(Either.right(List.of(CONCEPT_QUERY_1)));
+        when(translator.toQuery(CONCEPT_CRITERION_2)).thenReturn(Either.right(List.of(CONCEPT_QUERY_2)));
 
-        var result = service.translate(query).block();
+        var result = service.translate(query);
 
-        assertThat(result).isEqualTo(Operator.difference(Operator.intersection(Operator.union(
+        assertThat(result).isRightEqualTo(Operator.difference(Operator.intersection(Operator.union(
                 new QueryExpression(CONCEPT_QUERY_1))), Operator.union(Operator.intersection(Operator.union(
                 new QueryExpression(CONCEPT_QUERY_2))))));
     }
@@ -173,8 +166,8 @@ class StructuredQueryServiceTest {
     @Test
     void execute_twoIncludeConceptCriteria_orLevel() {
         var query = StructuredQuery.of(CriterionGroup.of(CriterionGroup.of(CONCEPT_CRITERION_1, CONCEPT_CRITERION_2)));
-        when(translator.toQuery(CONCEPT_CRITERION_1)).thenReturn(Mono.just(List.of(CONCEPT_QUERY_1)));
-        when(translator.toQuery(CONCEPT_CRITERION_2)).thenReturn(Mono.just(List.of(CONCEPT_QUERY_2)));
+        when(translator.toQuery(CONCEPT_CRITERION_1)).thenReturn(Either.right(List.of(CONCEPT_QUERY_1)));
+        when(translator.toQuery(CONCEPT_CRITERION_2)).thenReturn(Either.right(List.of(CONCEPT_QUERY_2)));
         when(fhirQueryService.execute(CONCEPT_QUERY_1)).thenReturn(Mono.just(Population.of(PATIENT_ID_1)));
         when(fhirQueryService.execute(CONCEPT_QUERY_2)).thenReturn(Mono.just(Population.of(PATIENT_ID_2)));
 
@@ -186,20 +179,20 @@ class StructuredQueryServiceTest {
     @Test
     void translate_twoIncludeConceptCriteria_orLevel() {
         var query = StructuredQuery.of(CriterionGroup.of(CriterionGroup.of(CONCEPT_CRITERION_1, CONCEPT_CRITERION_2)));
-        when(translator.toQuery(CONCEPT_CRITERION_1)).thenReturn(Mono.just(List.of(CONCEPT_QUERY_1)));
-        when(translator.toQuery(CONCEPT_CRITERION_2)).thenReturn(Mono.just(List.of(CONCEPT_QUERY_2)));
+        when(translator.toQuery(CONCEPT_CRITERION_1)).thenReturn(Either.right(List.of(CONCEPT_QUERY_1)));
+        when(translator.toQuery(CONCEPT_CRITERION_2)).thenReturn(Either.right(List.of(CONCEPT_QUERY_2)));
 
-        var result = service.translate(query).block();
+        var result = service.translate(query);
 
-        assertThat(result).isEqualTo(Operator.intersection(Operator.union(new QueryExpression(CONCEPT_QUERY_1),
+        assertThat(result).isRightEqualTo(Operator.intersection(Operator.union(new QueryExpression(CONCEPT_QUERY_1),
                 new QueryExpression(CONCEPT_QUERY_2))));
     }
 
     @Test
     void execute_twoIncludeConceptCriteria_andLevel_samePatient() {
         var query = StructuredQuery.of(CriterionGroup.of(CriterionGroup.of(CONCEPT_CRITERION_1), CriterionGroup.of(CONCEPT_CRITERION_2)));
-        when(translator.toQuery(CONCEPT_CRITERION_1)).thenReturn(Mono.just(List.of(CONCEPT_QUERY_1)));
-        when(translator.toQuery(CONCEPT_CRITERION_2)).thenReturn(Mono.just(List.of(CONCEPT_QUERY_2)));
+        when(translator.toQuery(CONCEPT_CRITERION_1)).thenReturn(Either.right(List.of(CONCEPT_QUERY_1)));
+        when(translator.toQuery(CONCEPT_CRITERION_2)).thenReturn(Either.right(List.of(CONCEPT_QUERY_2)));
         when(fhirQueryService.execute(CONCEPT_QUERY_1)).thenReturn(Mono.just(Population.of(PATIENT_ID)));
         when(fhirQueryService.execute(CONCEPT_QUERY_2)).thenReturn(Mono.just(Population.of(PATIENT_ID)));
 
@@ -211,20 +204,20 @@ class StructuredQueryServiceTest {
     @Test
     void translate_twoIncludeConceptCriteria_andLevel() {
         var query = StructuredQuery.of(CriterionGroup.of(CriterionGroup.of(CONCEPT_CRITERION_1), CriterionGroup.of(CONCEPT_CRITERION_2)));
-        when(translator.toQuery(CONCEPT_CRITERION_1)).thenReturn(Mono.just(List.of(CONCEPT_QUERY_1)));
-        when(translator.toQuery(CONCEPT_CRITERION_2)).thenReturn(Mono.just(List.of(CONCEPT_QUERY_2)));
+        when(translator.toQuery(CONCEPT_CRITERION_1)).thenReturn(Either.right(List.of(CONCEPT_QUERY_1)));
+        when(translator.toQuery(CONCEPT_CRITERION_2)).thenReturn(Either.right(List.of(CONCEPT_QUERY_2)));
 
-        var result = service.translate(query).block();
+        var result = service.translate(query);
 
-        assertThat(result).isEqualTo(Operator.intersection(Operator.union(new QueryExpression(CONCEPT_QUERY_1)),
+        assertThat(result).isRightEqualTo(Operator.intersection(Operator.union(new QueryExpression(CONCEPT_QUERY_1)),
                 Operator.union(new QueryExpression(CONCEPT_QUERY_2))));
     }
 
     @Test
     void execute_twoIncludeConceptCriteria_andLevel_differentPatients() {
         var query = StructuredQuery.of(CriterionGroup.of(CriterionGroup.of(CONCEPT_CRITERION_1), CriterionGroup.of(CONCEPT_CRITERION_2)));
-        when(translator.toQuery(CONCEPT_CRITERION_1)).thenReturn(Mono.just(List.of(CONCEPT_QUERY_1)));
-        when(translator.toQuery(CONCEPT_CRITERION_2)).thenReturn(Mono.just(List.of(CONCEPT_QUERY_2)));
+        when(translator.toQuery(CONCEPT_CRITERION_1)).thenReturn(Either.right(List.of(CONCEPT_QUERY_1)));
+        when(translator.toQuery(CONCEPT_CRITERION_2)).thenReturn(Either.right(List.of(CONCEPT_QUERY_2)));
         when(fhirQueryService.execute(CONCEPT_QUERY_1)).thenReturn(Mono.just(Population.of(PATIENT_ID_1)));
         when(fhirQueryService.execute(CONCEPT_QUERY_2)).thenReturn(Mono.just(Population.of(PATIENT_ID_2)));
 


### PR DESCRIPTION
If one criteria was expanded into more than about 680 expanded criteria, there was a StackOverflow deep into the reactive system.

We used Monos to track errors while expanding but didn't need the async processing while doing so. So I introduced a Either type to track errors and omit using reactive processing that isn't needed.

Closes: #35