### PR TITLE
Retry Failed Requests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,18 @@
       <artifactId>reactor-test</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>okhttp</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.squareup.okhttp3</groupId>
+      <artifactId>mockwebserver</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/test/java/de/medizininformatikinitiative/flare/service/DataStoreIT.java
+++ b/src/test/java/de/medizininformatikinitiative/flare/service/DataStoreIT.java
@@ -31,7 +31,7 @@ class DataStoreIT {
 
     private static final Logger logger = LoggerFactory.getLogger(DataStoreIT.class);
 
-    static final Instant FIXED_INSTANT = Instant.ofEpochSecond(104152);
+    private static final Instant FIXED_INSTANT = Instant.ofEpochSecond(104152);
 
     @Container
     @SuppressWarnings("resource")
@@ -104,7 +104,7 @@ class DataStoreIT {
 
     @Test
     @DisplayName("A single Resource without a Reference to a Patient is invalid and should not be counted")
-    void execute_OneObsWithoutReference_FromOnePat(){
+    void execute_OneObsWithoutReference_FromOnePat() {
         createObservation_withoutReference();
 
         var result = dataStore.execute(Query.ofType("Observation"));
@@ -114,8 +114,8 @@ class DataStoreIT {
 
     @Test
     @DisplayName("There is one Resource with a valid and one with an invalid Reference. Only the one with the valid" +
-                " Reference should be counted")
-    void execute_OneObsWithoutReferenceOneObsWithReference_FromTwoPats(){
+            " Reference should be counted")
+    void execute_OneObsWithoutReferenceOneObsWithReference_FromTwoPats() {
         createPatient("1");
         createObservation_withoutReference();
         createObservation("1");

--- a/src/test/java/de/medizininformatikinitiative/flare/service/DataStoreTest.java
+++ b/src/test/java/de/medizininformatikinitiative/flare/service/DataStoreTest.java
@@ -1,0 +1,81 @@
+package de.medizininformatikinitiative.flare.service;
+
+import de.medizininformatikinitiative.flare.model.Population;
+import de.medizininformatikinitiative.flare.model.fhir.Query;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.test.StepVerifier;
+
+import java.io.IOException;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+
+class DataStoreTest {
+
+    private static final Instant FIXED_INSTANT = Instant.ofEpochSecond(104152);
+    private static MockWebServer mockStore;
+
+    private DataStore dataStore;
+
+    @BeforeAll
+    static void setUp() throws IOException {
+        mockStore = new MockWebServer();
+        mockStore.start();
+    }
+
+    @AfterAll
+    static void tearDown() throws IOException {
+        mockStore.shutdown();
+    }
+
+    @BeforeEach
+    void initialize() {
+        WebClient client = WebClient.builder()
+                .baseUrl("http://localhost:%d/fhir".formatted(mockStore.getPort()))
+                .defaultHeader("Accept", "application/fhir+json")
+                .build();
+        dataStore = new DataStore(client, Clock.fixed(FIXED_INSTANT, ZoneOffset.UTC), 1000);
+    }
+
+    @ParameterizedTest
+    @DisplayName("retires the request")
+    @ValueSource(ints = {500, 503, 504})
+    void execute_retry(int statusCode) {
+        mockStore.enqueue(new MockResponse().setResponseCode(statusCode));
+        mockStore.enqueue(new MockResponse().setResponseCode(200));
+
+        var result = dataStore.execute(Query.ofType("Observation"));
+
+        StepVerifier.create(result).expectNext(Population.of().withCreated(FIXED_INSTANT)).verifyComplete();
+    }
+
+    @Test
+    @DisplayName("fails after 3 unsuccessful retires")
+    void execute_retry_fails() {
+        mockStore.enqueue(new MockResponse().setResponseCode(500));
+        mockStore.enqueue(new MockResponse().setResponseCode(500));
+        mockStore.enqueue(new MockResponse().setResponseCode(500));
+        mockStore.enqueue(new MockResponse().setResponseCode(500));
+        mockStore.enqueue(new MockResponse().setResponseCode(200));
+
+        var result = dataStore.execute(Query.ofType("Observation"));
+
+        StepVerifier.create(result).expectErrorMessage("Retries exhausted: 3/3").verify();
+    }
+
+    @Test
+    @DisplayName("doesn't retry a 400")
+    void execute_retry_400() {
+        mockStore.enqueue(new MockResponse().setResponseCode(400));
+
+        var result = dataStore.execute(Query.ofType("Observation"));
+
+        StepVerifier.create(result).expectError(WebClientResponseException.BadRequest.class).verify();
+    }
+}


### PR DESCRIPTION
This commit implements a three times exponential retry of 5xx requests starting with about 1 second and a maximum duration of about 7 seconds.