### PR TITLE
Don't Expand Abstract Term Code Tree Nodes

### DIFF
--- a/src/main/java/de/medizininformatikinitiative/flare/model/mapping/MappingContext.java
+++ b/src/main/java/de/medizininformatikinitiative/flare/model/mapping/MappingContext.java
@@ -57,7 +57,7 @@ public class MappingContext {
      * Tries to find the {@link Mapping} with the given {@code key}.
      *
      * @param key the TermCode of the mapping
-     * @return either the Mapping or {@code Optional#empty() nothing}
+     * @return either the Mapping or an exception
      */
     public Either<Exception, Mapping> findMapping(TermCode key) {
         var mapping = mappings.get(requireNonNull(key));
@@ -65,10 +65,10 @@ public class MappingContext {
     }
 
     /**
-     * Expands {@code concept} into a {@link Either either} of {@link TermCode term codes}.
+     * Expands {@code concept} into an {@link Either either} of {@link TermCode term codes}.
      *
      * @param concept the concept to expand
-     * @return the mono of term codes
+     * @return either a list of term codes or an exception
      */
     public Either<Exception, List<TermCode>> expandConcept(Concept concept) {
         var termCodes = concept.termCodes().stream().flatMap(conceptTree::expand).toList();

--- a/src/main/java/de/medizininformatikinitiative/flare/model/mapping/TermCodeNode.java
+++ b/src/main/java/de/medizininformatikinitiative/flare/model/mapping/TermCodeNode.java
@@ -14,39 +14,83 @@ import static java.util.Objects.requireNonNull;
  * @author Alexander Kiel
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record TermCodeNode(TermCode termCode, List<TermCodeNode> children) {
+public sealed interface TermCodeNode permits TermCodeNode.Abstract, TermCodeNode.Normal {
 
-    public TermCodeNode {
-        requireNonNull(termCode);
-        children = List.copyOf(children);
+    static TermCodeNode createAbstract(TermCode termCode, TermCodeNode... children) {
+        return new TermCodeNode.Abstract(termCode, children == null ? List.of() : List.of(children));
     }
 
-    public static TermCodeNode of(TermCode termCode) {
-        return new TermCodeNode(termCode, List.of());
+    static TermCodeNode createNormal(TermCode termCode, TermCodeNode... children) {
+        return new TermCodeNode.Normal(termCode, children == null ? List.of() : List.of(children));
     }
 
     @JsonCreator
-    public static TermCodeNode of(@JsonProperty("termCode") TermCode termCode,
-                                  @JsonProperty("children") TermCodeNode... children) {
-        return new TermCodeNode(requireNonNull(termCode, "missing JSON property: termCode"),
-                children == null ? List.of() : List.of(children));
+    static TermCodeNode fromJson(@JsonProperty("termCode") TermCode termCode,
+                                 @JsonProperty("abstract") boolean abstractJson,
+                                 @JsonProperty("children") TermCodeNode... children) {
+        requireNonNull(termCode, "missing JSON property: termCode");
+        return abstractJson
+                ? new Abstract(termCode, children == null ? List.of() : List.of(children))
+                : new Normal(termCode, children == null ? List.of() : List.of(children));
     }
 
-    public Stream<TermCode> expand(TermCode termCode) {
-        if (requireNonNull(termCode).equals(this.termCode)) {
-            return leafConcepts();
-        } else if (children.isEmpty()) {
-            return Stream.of();
-        } else {
-            return children.stream().flatMap(n -> n.expand(termCode));
+    Stream<TermCode> expand(TermCode termCode);
+
+    Stream<TermCode> leafConcepts();
+
+    TermCode termCode();
+
+    List<TermCodeNode> children();
+
+    record Abstract(TermCode termCode, List<TermCodeNode> children) implements TermCodeNode {
+
+        public Abstract {
+            requireNonNull(termCode);
+            children = List.copyOf(children);
+        }
+
+        @Override
+        public Stream<TermCode> expand(TermCode termCode) {
+            if (requireNonNull(termCode).equals(this.termCode)) {
+                return leafConcepts();
+            } else if (children.isEmpty()) {
+                return Stream.of();
+            } else {
+                return children.stream().flatMap(n -> n.expand(termCode));
+            }
+        }
+
+        @Override
+        public Stream<TermCode> leafConcepts() {
+            return children.isEmpty() ? Stream.of() : children.stream().flatMap(TermCodeNode::leafConcepts);
         }
     }
 
-    private Stream<TermCode> leafConcepts() {
-        if (children.isEmpty()) {
-            return Stream.of(termCode);
-        } else {
-            return Stream.concat(Stream.of(termCode), children.stream().flatMap(TermCodeNode::leafConcepts));
+    record Normal(TermCode termCode, List<TermCodeNode> children) implements TermCodeNode {
+
+        public Normal {
+            requireNonNull(termCode);
+            children = List.copyOf(children);
+        }
+
+        @Override
+        public Stream<TermCode> expand(TermCode termCode) {
+            if (requireNonNull(termCode).equals(this.termCode)) {
+                return leafConcepts();
+            } else if (children.isEmpty()) {
+                return Stream.of();
+            } else {
+                return children.stream().flatMap(n -> n.expand(termCode));
+            }
+        }
+
+        @Override
+        public Stream<TermCode> leafConcepts() {
+            if (children.isEmpty()) {
+                return Stream.of(termCode);
+            } else {
+                return Stream.concat(Stream.of(termCode), children.stream().flatMap(TermCodeNode::leafConcepts));
+            }
         }
     }
 }

--- a/src/test/java/de/medizininformatikinitiative/flare/model/mapping/MappingContextTest.java
+++ b/src/test/java/de/medizininformatikinitiative/flare/model/mapping/MappingContextTest.java
@@ -1,0 +1,46 @@
+package de.medizininformatikinitiative.flare.model.mapping;
+
+import de.medizininformatikinitiative.flare.model.sq.Concept;
+import de.medizininformatikinitiative.flare.model.sq.TermCode;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static de.medizininformatikinitiative.flare.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MappingContextTest {
+
+    static final TermCode ROOT = TermCode.of("root", "root", "root");
+    static final TermCode C1 = TermCode.of("foo", "c1", "c1");
+    static final TermCode C11 = TermCode.of("foo", "c11", "c11");
+    static final TermCode C12 = TermCode.of("foo", "c12", "c12");
+
+    @Test
+    void expandConcept_ConceptNotExpandable() {
+        var context = MappingContext.of(Map.of(), TermCodeNode.createNormal(ROOT));
+
+        var result = context.expandConcept(Concept.of(C1));
+
+        assertThat(result).isLeftInstanceOf(ConceptNotExpandableException.class);
+    }
+
+    @Test
+    void expandConcept_OneConcept() {
+        var context = MappingContext.of(Map.of(), TermCodeNode.createNormal(ROOT, TermCodeNode.createNormal(C1)));
+
+        var result = context.expandConcept(Concept.of(C1));
+
+        assertThat(result).isRightSatisfying(r -> assertThat(r).containsExactly(C1));
+    }
+
+    @Test
+    void expandConcept_TwoConcepts() {
+        var context = MappingContext.of(Map.of(), TermCodeNode.createAbstract(C1, TermCodeNode.createNormal(C11),
+                TermCodeNode.createNormal(C12)));
+
+        var result = context.expandConcept(Concept.of(C1));
+
+        assertThat(result).isRightSatisfying(r -> assertThat(r).containsExactly(C11, C12));
+    }
+}

--- a/src/test/java/de/medizininformatikinitiative/flare/model/mapping/TermCodeNodeTest.java
+++ b/src/test/java/de/medizininformatikinitiative/flare/model/mapping/TermCodeNodeTest.java
@@ -18,14 +18,14 @@ class TermCodeNodeTest {
 
     @Test
     void noChildren() {
-        var node = TermCodeNode.of(ROOT);
+        var node = TermCodeNode.createNormal(ROOT);
 
         assertThat(node.children()).isEmpty();
     }
 
     @Test
     void expand_notFound() {
-        var node = TermCodeNode.of(ROOT);
+        var node = TermCodeNode.createNormal(ROOT);
 
         var result = node.expand(C1).toList();
 
@@ -34,7 +34,7 @@ class TermCodeNodeTest {
 
     @Test
     void expand_itSelf_asLeaf() {
-        var node = TermCodeNode.of(ROOT);
+        var node = TermCodeNode.createNormal(ROOT);
 
         var result = node.expand(ROOT).toList();
 
@@ -42,8 +42,17 @@ class TermCodeNodeTest {
     }
 
     @Test
-    void expand_itSelf_withChildren() {
-        var node = TermCodeNode.of(ROOT, TermCodeNode.of(C1), TermCodeNode.of(C2));
+    void expand_itSelf_withChildren_abstract() {
+        var node = TermCodeNode.createAbstract(ROOT, TermCodeNode.createNormal(C1), TermCodeNode.createNormal(C2));
+
+        var result = node.expand(ROOT).toList();
+
+        assertThat(result).containsExactly(C1, C2);
+    }
+
+    @Test
+    void expand_itSelf_withChildren_normal() {
+        var node = TermCodeNode.createNormal(ROOT, TermCodeNode.createNormal(C1), TermCodeNode.createNormal(C2));
 
         var result = node.expand(ROOT).toList();
 
@@ -52,8 +61,8 @@ class TermCodeNodeTest {
 
     @Test
     void expand_child_withChildren() {
-        var c1 = TermCodeNode.of(C1, TermCodeNode.of(C11), TermCodeNode.of(C12));
-        var node = TermCodeNode.of(ROOT, c1, TermCodeNode.of(C2));
+        var c1 = TermCodeNode.createNormal(C1, TermCodeNode.createNormal(C11), TermCodeNode.createNormal(C12));
+        var node = TermCodeNode.createNormal(ROOT, c1, TermCodeNode.createNormal(C2));
 
         var result = node.expand(C1).toList();
 
@@ -62,9 +71,9 @@ class TermCodeNodeTest {
 
     @Test
     void expand_child_deep() {
-        var c11 = TermCodeNode.of(C11, TermCodeNode.of(C111), TermCodeNode.of(C112));
-        var c1 = TermCodeNode.of(C1, c11, TermCodeNode.of(C12));
-        var node = TermCodeNode.of(ROOT, c1, TermCodeNode.of(C2));
+        var c11 = TermCodeNode.createNormal(C11, TermCodeNode.createNormal(C111), TermCodeNode.createNormal(C112));
+        var c1 = TermCodeNode.createNormal(C1, c11, TermCodeNode.createNormal(C12));
+        var node = TermCodeNode.createNormal(ROOT, c1, TermCodeNode.createNormal(C2));
 
         var result = node.expand(C1).toList();
 


### PR DESCRIPTION
I introduced a new property called "abstract" to the term code tree node that will not return it's term code in the expansion. The behaviour on the current tree files will not change but new tree files can use that "abstract" property.

See also: https://github.com/medizininformatik-initiative/sq2cql/issues/7