### PR TITLE
Migrate from GitFlow to GitHubFlow

### DIFF
--- a/.github/integration-test/basic-auth/docker-compose.yml
+++ b/.github/integration-test/basic-auth/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   data-store:
-    image: "samply/blaze:0.31"
+    image: "samply/blaze:0.32"
     healthcheck:
       test: ["CMD-SHELL", "curl --fail -s http://localhost:8080/health"]
       interval: "5s"

--- a/.github/integration-test/basic-auth/docker-compose.yml
+++ b/.github/integration-test/basic-auth/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     depends_on:
       - data-store
   proxy:
-    image: "nginx:1.27.3"
+    image: "nginx:1.27.4"
     volumes:
       - "./nginx.conf:/etc/nginx/nginx.conf"
       - "./proxy.htpasswd:/etc/auth/.htpasswd"

--- a/.github/integration-test/basic-auth/docker-compose.yml
+++ b/.github/integration-test/basic-auth/docker-compose.yml
@@ -37,7 +37,7 @@ services:
     depends_on:
       - data-store
   proxy:
-    image: "nginx:1.27.4"
+    image: "nginx:1.28.0"
     volumes:
       - "./nginx.conf:/etc/nginx/nginx.conf"
       - "./proxy.htpasswd:/etc/auth/.htpasswd"

--- a/.github/integration-test/basic-auth/docker-compose.yml
+++ b/.github/integration-test/basic-auth/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   data-store:
-    image: "samply/blaze:0.32"
+    image: "samply/blaze:0.33"
     healthcheck:
       test: ["CMD-SHELL", "curl --fail -s http://localhost:8080/health"]
       interval: "5s"

--- a/.github/integration-test/basic-auth/docker-compose.yml
+++ b/.github/integration-test/basic-auth/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   data-store:
-    image: "samply/blaze:0.33"
+    image: "samply/blaze:0.34"
     healthcheck:
       test: ["CMD-SHELL", "curl --fail -s http://localhost:8080/health"]
       interval: "5s"

--- a/.github/integration-test/no-auth-cohort-enabled/docker-compose.yml
+++ b/.github/integration-test/no-auth-cohort-enabled/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   data-store:
-    image: "samply/blaze:0.31"
+    image: "samply/blaze:0.32"
     healthcheck:
       test: ["CMD-SHELL", "curl --fail -s http://localhost:8080/health"]
       interval: "5s"

--- a/.github/integration-test/no-auth-cohort-enabled/docker-compose.yml
+++ b/.github/integration-test/no-auth-cohort-enabled/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   data-store:
-    image: "samply/blaze:0.32"
+    image: "samply/blaze:0.33"
     healthcheck:
       test: ["CMD-SHELL", "curl --fail -s http://localhost:8080/health"]
       interval: "5s"

--- a/.github/integration-test/no-auth-cohort-enabled/docker-compose.yml
+++ b/.github/integration-test/no-auth-cohort-enabled/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   data-store:
-    image: "samply/blaze:0.33"
+    image: "samply/blaze:0.34"
     healthcheck:
       test: ["CMD-SHELL", "curl --fail -s http://localhost:8080/health"]
       interval: "5s"

--- a/.github/integration-test/no-auth/docker-compose.yml
+++ b/.github/integration-test/no-auth/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   data-store:
-    image: "samply/blaze:0.31"
+    image: "samply/blaze:0.32"
     healthcheck:
       test: ["CMD-SHELL", "curl --fail -s http://localhost:8080/health"]
       interval: "5s"

--- a/.github/integration-test/no-auth/docker-compose.yml
+++ b/.github/integration-test/no-auth/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   data-store:
-    image: "samply/blaze:0.32"
+    image: "samply/blaze:0.33"
     healthcheck:
       test: ["CMD-SHELL", "curl --fail -s http://localhost:8080/health"]
       interval: "5s"

--- a/.github/integration-test/no-auth/docker-compose.yml
+++ b/.github/integration-test/no-auth/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   data-store:
-    image: "samply/blaze:0.33"
+    image: "samply/blaze:0.34"
     healthcheck:
       test: ["CMD-SHELL", "curl --fail -s http://localhost:8080/health"]
       interval: "5s"

--- a/.github/integration-test/oauth/docker-compose.yml
+++ b/.github/integration-test/oauth/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       generate-cert:
         condition: service_completed_successfully
   keycloak:
-    image: "keycloak/keycloak:26.1.2"
+    image: "keycloak/keycloak:26.1.4"
     command: ["start", "--import-realm"]
     healthcheck:
       test: ["CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/9000;echo -e \"GET /health/ready HTTP/1.1\r\nhost: localhost\r\nConnection: close\r\n\r\n\" >&3;grep \"HTTP/1.1 200 OK\" <&3"]

--- a/.github/integration-test/oauth/docker-compose.yml
+++ b/.github/integration-test/oauth/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       generate-cert:
         condition: service_completed_successfully
   keycloak:
-    image: "keycloak/keycloak:26.2.2"
+    image: "keycloak/keycloak:26.2.3"
     command: ["start", "--import-realm"]
     healthcheck:
       test: ["CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/9000;echo -e \"GET /health/ready HTTP/1.1\r\nhost: localhost\r\nConnection: close\r\n\r\n\" >&3;grep \"HTTP/1.1 200 OK\" <&3"]

--- a/.github/integration-test/oauth/docker-compose.yml
+++ b/.github/integration-test/oauth/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       generate-cert:
         condition: service_completed_successfully
   keycloak:
-    image: "keycloak/keycloak:26.1.4"
+    image: "keycloak/keycloak:26.2.0"
     command: ["start", "--import-realm"]
     healthcheck:
       test: ["CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/9000;echo -e \"GET /health/ready HTTP/1.1\r\nhost: localhost\r\nConnection: close\r\n\r\n\" >&3;grep \"HTTP/1.1 200 OK\" <&3"]

--- a/.github/integration-test/oauth/docker-compose.yml
+++ b/.github/integration-test/oauth/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       keycloak:
         condition: service_healthy
   data-store:
-    image: "samply/blaze:0.33"
+    image: "samply/blaze:0.34"
     healthcheck:
       test: ["CMD-SHELL", "curl --fail -s http://localhost:8080/health"]
       interval: "5s"

--- a/.github/integration-test/oauth/docker-compose.yml
+++ b/.github/integration-test/oauth/docker-compose.yml
@@ -50,7 +50,7 @@ services:
     volumes:
       - "./realm-test.json:/opt/keycloak/data/import/realm-test.json"
   proxy:
-    image: "nginx:1.27.3"
+    image: "nginx:1.27.4"
     healthcheck:
       test: ["CMD-SHELL", "curl --fail -s http://localhost:8080"]
       interval: "5s"

--- a/.github/integration-test/oauth/docker-compose.yml
+++ b/.github/integration-test/oauth/docker-compose.yml
@@ -50,7 +50,7 @@ services:
     volumes:
       - "./realm-test.json:/opt/keycloak/data/import/realm-test.json"
   proxy:
-    image: "nginx:1.27.4"
+    image: "nginx:1.28.0"
     healthcheck:
       test: ["CMD-SHELL", "curl --fail -s http://localhost:8080"]
       interval: "5s"

--- a/.github/integration-test/oauth/docker-compose.yml
+++ b/.github/integration-test/oauth/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       keycloak:
         condition: service_healthy
   data-store:
-    image: "samply/blaze:0.32"
+    image: "samply/blaze:0.33"
     healthcheck:
       test: ["CMD-SHELL", "curl --fail -s http://localhost:8080/health"]
       interval: "5s"

--- a/.github/integration-test/oauth/docker-compose.yml
+++ b/.github/integration-test/oauth/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       generate-cert:
         condition: service_completed_successfully
   keycloak:
-    image: "keycloak/keycloak:26.2.0"
+    image: "keycloak/keycloak:26.2.2"
     command: ["start", "--import-realm"]
     healthcheck:
       test: ["CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/9000;echo -e \"GET /health/ready HTTP/1.1\r\nhost: localhost\r\nConnection: close\r\n\r\n\" >&3;grep \"HTTP/1.1 200 OK\" <&3"]

--- a/.github/integration-test/oauth/docker-compose.yml
+++ b/.github/integration-test/oauth/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       generate-cert:
         condition: service_completed_successfully
   keycloak:
-    image: "keycloak/keycloak:25.0.6"
+    image: "keycloak/keycloak:26.1.2"
     command: ["start", "--import-realm"]
     healthcheck:
       test: ["CMD-SHELL", "exec 3<>/dev/tcp/127.0.0.1/9000;echo -e \"GET /health/ready HTTP/1.1\r\nhost: localhost\r\nConnection: close\r\n\r\n\" >&3;grep \"HTTP/1.1 200 OK\" <&3"]

--- a/.github/integration-test/oauth/docker-compose.yml
+++ b/.github/integration-test/oauth/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       keycloak:
         condition: service_healthy
   data-store:
-    image: "samply/blaze:0.31"
+    image: "samply/blaze:0.32"
     healthcheck:
       test: ["CMD-SHELL", "curl --fail -s http://localhost:8080/health"]
       interval: "5s"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21.0.6_7-jre-noble@sha256:c42ef675fc9ff8a662a03eec2e6719133c736681068d474f96bc1a6139f99904
+FROM eclipse-temurin:21.0.7_6-jre-noble@sha256:ce9014ea8f38b2810e648f8497c2f8d2fa76318a7d476152ce4fddf86ae980d7
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21.0.7_6-jre-noble@sha256:ce9014ea8f38b2810e648f8497c2f8d2fa76318a7d476152ce4fddf86ae980d7
+FROM eclipse-temurin:21.0.7_6-jre-noble@sha256:c06eb1dfa2c701a00fdc9e6ad57a7b667eee093f8361781023c3aee6815ef713
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21.0.6_7-jre-noble@sha256:3ef64ec531571987f58ccc90bd3d7f92950539f1baa00a5c45b660d6faccf37d
+FROM eclipse-temurin:21.0.6_7-jre-noble@sha256:c42ef675fc9ff8a662a03eec2e6719133c736681068d474f96bc1a6139f99904
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
-FROM eclipse-temurin:21.0.5_11-jre-jammy@sha256:5f8358c9d5615c18e95728e8b8528bda7ff40a7a5da2ac9a35b7a01f5d9b231a
+FROM eclipse-temurin:21.0.6_7-jre-noble@sha256:3ef64ec531571987f58ccc90bd3d7f92950539f1baa00a5c45b660d6faccf37d
 
-RUN apt-get update && apt-get upgrade -y && \
-    apt-get purge wget libbinutils libctf0 libctf-nobfd0 libncurses6 -y && \
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install libjemalloc2 -y && \
+    apt-get purge wget libncurses6 -y && \
     apt-get autoremove -y && apt-get clean && \
     rm -rf /var/lib/apt/lists/
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -33,6 +33,12 @@ An example `<query>` is:
             }
           ],
           "type": "concept"
+        },
+        "context": {
+          "code": "Patient",
+          "display": "Patient",
+          "system": "fdpg.mii.cds",
+          "version": "1.0.0"
         }
       }
     ]
@@ -81,6 +87,12 @@ An example `<query>` is:
             }
           ],
           "type": "concept"
+        },
+        "context": {
+          "code": "Patient",
+          "display": "Patient",
+          "system": "fdpg.mii.cds",
+          "version": "1.0.0"
         }
       }
     ]
@@ -176,6 +188,12 @@ The example query is:
           },
           "value": 5,
           "comparator": "gt"
+        },
+        "context": {
+          "code": "Patient",
+          "display": "Patient",
+          "system": "fdpg.mii.cds",
+          "version": "1.0.0"
         }
       },
       {
@@ -195,6 +213,12 @@ The example query is:
             }
           ],
           "type": "concept"
+        },
+        "context": {
+          "code": "Patient",
+          "display": "Patient",
+          "system": "fdpg.mii.cds",
+          "version": "1.0.0"
         }
       }
     ]
@@ -218,6 +242,12 @@ The example query is:
             }
           ],
           "type": "concept"
+        },
+        "context": {
+          "code": "Patient",
+          "display": "Patient",
+          "system": "fdpg.mii.cds",
+          "version": "1.0.0"
         }
       }
     ]

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.4.2</version>
+    <version>3.4.3</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.4.4</version>
+    <version>3.4.5</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.4.3</version>
+    <version>3.4.4</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.4.1</version>
+    <version>3.4.2</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <properties>
     <java.version>17</java.version>
-    <testcontainers.version>1.20.4</testcontainers.version>
+    <testcontainers.version>1.20.6</testcontainers.version>
     <ontology.version>3.0.1</ontology.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>org.rocksdb</groupId>
       <artifactId>rocksdbjni</artifactId>
-      <version>9.8.4</version>
+      <version>9.10.0</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>org.rocksdb</groupId>
       <artifactId>rocksdbjni</artifactId>
-      <version>9.10.0</version>
+      <version>10.0.1</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
-      <version>3.1.8</version>
+      <version>3.2.0</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <properties>
     <java.version>17</java.version>
     <testcontainers.version>1.20.6</testcontainers.version>
-    <ontology.version>3.0.1</ontology.version>
+    <ontology.version>3.2.2</ontology.version>
   </properties>
 
   <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <properties>
     <java.version>17</java.version>
-    <testcontainers.version>1.20.6</testcontainers.version>
+    <testcontainers.version>1.21.0</testcontainers.version>
     <ontology.version>3.2.2</ontology.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>2.3</version>
+      <version>2.4</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -160,7 +160,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.12</version>
+        <version>0.8.13</version>
         <executions>
           <execution>
             <id>prepare-agent</id>


### PR DESCRIPTION
We will go to GitHubFlow because the extra develop branch doesn't have benefits anymore and everything works better with main-only.